### PR TITLE
Build cleanly with more a modern toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 SET(BOOST_ROOT "D:\\Boost")
 SET(Boost_USE_STATIC_LIBS ON)
 SET(Boost_USE_MULTITHREADED ON)
-FIND_PACKAGE(Boost 1.42.0 COMPONENTS system unit_test_framework)
+FIND_PACKAGE(Boost 1.66.0 COMPONENTS system unit_test_framework)
 
 #Documentation stuff
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #Preamble
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.10)
 project (STL::Cache)
 
 #Environment detection

--- a/UseDoxygen.cmake
+++ b/UseDoxygen.cmake
@@ -30,15 +30,15 @@
 #  DOXYFILE_EXTRA_SOURCES - Additional source diretories/files for Doxygen to scan.
 #  	The Paths should be in double quotes and separated by space. e.g.:
 #  	 "${CMAKE_CURRENT_BINARY_DIR}/foo.c" "${CMAKE_CURRENT_BINARY_DIR}/bar/"
-#  
+#
 #  DOXYFILE_OUTPUT_DIR - Path where the Doxygen output is stored.
 #  	Defaults to "${CMAKE_CURRENT_BINARY_DIR}/doc".
-#  
+#
 #  DOXYFILE_LATEX - ON/OFF; Set to "ON" if you want the LaTeX documentation
 #  	to be built.
 #  DOXYFILE_LATEX_DIR - Directory relative to DOXYFILE_OUTPUT_DIR where
 #  	the Doxygen LaTeX output is stored. Defaults to "latex".
-#  
+#
 #  DOXYFILE_HTML_DIR - Directory relative to DOXYFILE_OUTPUT_DIR where
 #  	the Doxygen html output is stored. Defaults to "html".
 #
@@ -87,14 +87,14 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 		DOXYFILE_SOURCE_DIR DOXYFILE_EXTRA_SOURCE_DIRS DOXYFILE_IN)
 
 
-	set_property(DIRECTORY 
+	set_property(DIRECTORY
 		APPEND PROPERTY
 		ADDITIONAL_MAKE_CLEAN_FILES
 		"${DOXYFILE_OUTPUT_DIR}/${DOXYFILE_HTML_DIR}")
 
 	add_custom_target(doxygen
 		COMMAND "${DOXYGEN_EXECUTABLE}"
-			"${DOXYFILE}" 
+			"${DOXYFILE}"
 		COMMENT "Writing documentation to ${DOXYFILE_OUTPUT_DIR}..."
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -134,10 +134,7 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file("${DOXYFILE_IN}" "${DOXYFILE}" @ONLY)
 
-	get_target_property(DOC_TARGET doc TYPE)
-	if(NOT DOC_TARGET)
-		add_custom_target(doc)
-	endif()
+	add_custom_target(doc)
 
 	add_dependencies(doc doxygen)
 endif()

--- a/include/stlcache/exceptions.hpp
+++ b/include/stlcache/exceptions.hpp
@@ -11,128 +11,128 @@
 namespace stlcache{
     /*!
      * \brief Base class for STL::Cache exceptions
-     *  
-     * Wrapper over std::runtime_error, base for all other STL::Cache exceptions classes. Since it's derived from the standard library exception class, 
+     *
+     * Wrapper over std::runtime_error, base for all other STL::Cache exceptions classes. Since it's derived from the standard library exception class,
      * it could be catched like other standard exceptions. Also usefull for catching  all cache specific exceptions.
-     *  
-     * \see exception_empty_victim 
-     * \see exception_invalid_key 
-     * \see exception_invalid_policy 
-     * \see exception_cache_full 
-     *  
+     *
+     * \see exception_empty_victim
+     * \see exception_invalid_key
+     * \see exception_invalid_policy
+     * \see exception_cache_full
+     *
      * \author chollya (5/20/2011)
      */
     class exception_base : public std::runtime_error {
     public:
         /*!
-         * \brief Exception constructor 
-         *  
+         * \brief Exception constructor
+         *
          * The constructor takes a standard string object as parameter. This value is stored in the object, and its value is used to generate the C-string returned by its inherited member what.
-         * 
+         *
          * \param what exception message
          */
         exception_base(const std::string &what) : std::runtime_error(what) {  }
     };
-    
+
     /*!
-     * \brief Empty victim access error 
-     *  
-     * Used by \link stlcache::_victim victim wrapper \endlink and thrown when someone tries to get access to the wrapper's data on a empty wrapper. 
-     * Usually this exception is handled by the cache itself and not very frequently used at the wild nature. 
-     *  
-     * \see stlcache::_victim 
-     *  
+     * \brief Empty victim access error
+     *
+     * Used by \link stlcache::_victim victim wrapper \endlink and thrown when someone tries to get access to the wrapper's data on a empty wrapper.
+     * Usually this exception is handled by the cache itself and not very frequently used at the wild nature.
+     *
+     * \see stlcache::_victim
+     *
      * \author chollya (5/20/2011)
      */
     class exception_empty_victim : public std::runtime_error {
     public:
         /*!
-         * \brief Exception constructor 
-         *  
+         * \brief Exception constructor
+         *
          * The constructor takes a standard string object as parameter. This value is stored in the object, and its value is used to generate the C-string returned by its inherited member what.
-         * 
+         *
          * \param what exception message
          */
         exception_empty_victim(const std::string &what) : std::runtime_error(what) {  }
     };
 
     /*!
-     * \brief Non-existent or non-acceptable key error 
-     *  
-     * Used by policies and cache. Could be thrown when someone tries to \link cache::fetch fetch \endlink key, that doesn't exists in the cache. 
-     * Policy could rise this exception too, when supplied with the key, that couldn't be accepted by the policy due to some reasons (you could inspect 
-     * message, carried with the exception, for details). So the \link cache::insert insert operation \endlink could result in this exception too. 
-     *  
-     * \see cache::insert 
-     * \see cache::fetch 
-     *  
+     * \brief Non-existent or non-acceptable key error
+     *
+     * Used by policies and cache. Could be thrown when someone tries to \link cache::fetch fetch \endlink key, that doesn't exists in the cache.
+     * Policy could rise this exception too, when supplied with the key, that couldn't be accepted by the policy due to some reasons (you could inspect
+     * message, carried with the exception, for details). So the \link cache::insert insert operation \endlink could result in this exception too.
+     *
+     * \see cache::insert
+     * \see cache::fetch
+     *
      * \author chollya (5/20/2011)
      */
     class exception_invalid_key : public std::runtime_error {
         const void* k;
     public:
         /*!
-         * \brief Exception constructor 
-         *  
+         * \brief Exception constructor
+         *
          * The constructor takes a standard string object and a problematic key value as parameters. The string value is stored in the object and  is used to generate the C-string returned by its inherited member what.
-         *  
+         *
          * \tparam  <Key> type of problematic key
-         *  
-         * \param what exception message 
-         * \param _k problematic key 
+         *
+         * \param what exception message
+         * \param _k problematic key
          */
         template <class Key>  exception_invalid_key(const std::string &what, const Key& _k) : std::runtime_error(what),k(&_k) {  }
         /*!
          * \brief Accessor for a problematic key
-         *  
-         * This exception carries the value of the key, that was the reason of throwing this exception, and key function is used to examine its value. 
-         *  
-         * \tparam <Key> type of problematic key 
-         *  
+         *
+         * This exception carries the value of the key, that was the reason of throwing this exception, and key function is used to examine its value.
+         *
+         * \tparam <Key> type of problematic key
+         *
          * \return the problematic key
-         *  
+         *
          */
         template <class Key> const Key& key() { return *((Key*)k); }
     };
 
     /*!
-     * \brief Incompatible policy error 
-     *  
-     * Thrown by \link cache::swap swap \endlink method, when someone tries to swap two caches with different policies or policies, configured in a different ways. 
-     *  
-     * \see cache::swap 
-     *  
+     * \brief Incompatible policy error
+     *
+     * Thrown by \link cache::swap swap \endlink method, when someone tries to swap two caches with different policies or policies, configured in a different ways.
+     *
+     * \see cache::swap
+     *
      * \author chollya (5/20/2011)
      */
     class exception_invalid_policy : public std::runtime_error {
     public:
         /*!
-         * \brief Exception constructor 
-         *  
+         * \brief Exception constructor
+         *
          * The constructor takes a standard string object as parameter. This value is stored in the object, and its value is used to generate the C-string returned by its inherited member what.
-         * 
+         *
          * \param what exception message
          */
         exception_invalid_policy(const std::string &what) : std::runtime_error(what) {  }
     };
 
     /*!
-     * \brief Cache overflow error 
-     *  
-     * Thrown when the cache is full and no entry could be expired at the moment. 
-     *  
-     * \see stlcache::policy 
-     * \see cache::insert 
-     * 
+     * \brief Cache overflow error
+     *
+     * Thrown when the cache is full and no entry could be expired at the moment.
+     *
+     * \see stlcache::policy
+     * \see cache::insert
+     *
      * \author chollya (5/20/2011)
      */
     class exception_cache_full : public std::runtime_error {
     public:
         /*!
-         * \brief Exception constructor 
-         *  
+         * \brief Exception constructor
+         *
          * The constructor takes a standard string object as parameter. This value is stored in the object, and its value is used to generate the C-string returned by its inherited member what.
-         * 
+         *
          * \param what exception message
          */
         exception_cache_full(const std::string &what) : std::runtime_error(what) {  }

--- a/include/stlcache/policy.hpp
+++ b/include/stlcache/policy.hpp
@@ -17,41 +17,41 @@ using namespace std;
 
 namespace stlcache {
     /*! \brief Abstract interface of a cache entries expiration policy.
-     * 
-     * policy class defines, what methods are expected by \link stlcache::cache cache \endlink from the policy. Usually you will never be using this class directly, 
-     * but it is you key for writing your custom policies. Actually the policy classes, that you are using with the \link stlcache::cache cache \endlink 
-     * are just wrappers over real policy implementation (derived from the policy interface), used for binding. So you are able to add your own 
-     * template parameters to your policies, like we are doing it in a \link stlcache::policy_lfuaging LFU-Aging policy \endlink 
-     * 
+     *
+     * policy class defines, what methods are expected by \link stlcache::cache cache \endlink from the policy. Usually you will never be using this class directly,
+     * but it is you key for writing your custom policies. Actually the policy classes, that you are using with the \link stlcache::cache cache \endlink
+     * are just wrappers over real policy implementation (derived from the policy interface), used for binding. So you are able to add your own
+     * template parameters to your policies, like we are doing it in a \link stlcache::policy_lfuaging LFU-Aging policy \endlink
+     *
      * The goal of writing such policy classes is to provide a \link stlcache::cache cache \endlink with a several, configurable cache expiration
      * implementations. The policy should know about keys of the entries in the cache and it must be able to give a cache one or several entries that are 'expired'
      * and could be removed from it. So the interface is targeted to this goal.
-     * 
-     * For example, the \link stlcache::policy_none None policy \endlink is implemented in the following way: 
-     *  
-     * \code  
-     *    template <class Key, template <typename T> class Allocator> class _policy_none_type : public policy<Key,Allocator> { 
-     *         //Skipping actual implementation of abstract methods 
+     *
+     * For example, the \link stlcache::policy_none None policy \endlink is implemented in the following way:
+     *
+     * \code
+     *    template <class Key, template <typename T> class Allocator> class _policy_none_type : public policy<Key,Allocator> {
+     *         //Skipping actual implementation of abstract methods
      *     };
      *
      *     struct policy_none {
      *       template <typename Key, template <typename T> class Allocator>
-     *          struct bind : _policy_none_type<Key,Allocator> { 
+     *          struct bind : _policy_none_type<Key,Allocator> {
      *             bind(const bind& x) : _policy_none_type<Key,Allocator>(x)  { }
      *             bind(const size_t& size) : _policy_none_type<Key,Allocator>(size) { }
      *         };
      *     };
-     * 
+     *
      *     \endcode
-     * 
-     *     Details of the implementation of the any of the policies are not documented and subject to change, but you still may read the sources. 
-     * 
+     *
+     *     Details of the implementation of the any of the policies are not documented and subject to change, but you still may read the sources.
+     *
      *     All policies are configured with the cache's key type and used allocator. It is expected, that policy uses supplied allocator type when doing internal
      *     memory allocations.
-     * 
+     *
      *     \tparam <Key> The cache's Key data type
      *     \tparam <Allocator> Type of the allocator object used to define the allocation model.
-     * 
+     *
      *     \see stlcache::cache
      *     \see stlcache::policy_none
      *     \see stlcache::policy_lru
@@ -61,88 +61,88 @@ namespace stlcache {
      *     \see stlcache::policy_lfuaging
      *     \see stlcache::policy_lfuagingstar
      *     \see stlcache::policy_adaptive
-     * 
+     *
      * \author chollya (5/19/2011)
      */
     template <class Key,template <typename T> class Allocator> class policy {
     public:
         /*!
          * \brief handles insertion of a key to the cache
-         *  
+         *
          *  Cache calls this method before a key insertion, but only if the cache have some free space (or have cleared some free space). Implementation
          *  could store the key somewhere (and it is safe, to keep only a reference to it) and keep it for future use.
-         *  
+         *
          *  \param <_k> reference to a key value, being inserted
-         *  
+         *
          *  \throw <exception_invalid_key> Thrown when key could not be accepted by the policy (for example when it's not unique or there is some other issue). The insertion into main cache will be cancelled too.
-         *  
+         *
          *  \see cache::insert
-         *  
+         *
          */
         virtual void insert(const Key& _k) =0;
         /*!
-         * \brief handles deletion of a entry from the cache 
-         *  
-         * After removal of a key from the cache storage itself, the cache will notify a policy of entry removal, by calling this method. Implementation 
-         * must erase (or forgot) about the key and any data that belongs to it. 
-         *  
-         * \param <_k> reference to a key being deleted 
-         *  
-         * \see cache::erase 
-         * 
+         * \brief handles deletion of a entry from the cache
+         *
+         * After removal of a key from the cache storage itself, the cache will notify a policy of entry removal, by calling this method. Implementation
+         * must erase (or forgot) about the key and any data that belongs to it.
+         *
+         * \param <_k> reference to a key being deleted
+         *
+         * \see cache::erase
+         *
          */
         virtual void remove(const Key& _k) =0;
         /*!
          * \brief marks that the specified entry is used by cache
-         *  
-         * Several cache operations are calling this method. In general words, touch() is a way, to tell the policy, that entry with specified key is being used 
-         * somehow. The policy implementation may (or may not) use this knowledge for expired items selection. 
-         *  
-         * \param <_k> reference to key being used 
-         *  
-         * \see cache::touch 
-         * \see cache::fetch 
-         * \see cache::check 
-         *  
+         *
+         * Several cache operations are calling this method. In general words, touch() is a way, to tell the policy, that entry with specified key is being used
+         * somehow. The policy implementation may (or may not) use this knowledge for expired items selection.
+         *
+         * \param <_k> reference to key being used
+         *
+         * \see cache::touch
+         * \see cache::fetch
+         * \see cache::check
+         *
          */
         virtual void touch(const Key& _k) =0;
         /*!
-         * \brief clear call helper 
-         *  
-         * Called by cache during it's own \link cache::clear clear \endlink call. Implemention of this method should drop all it's knowledge about the 
-         * keys and their usage and start from scratch. 
-         *  
-         * \see cache::clear 
-         *  
+         * \brief clear call helper
+         *
+         * Called by cache during it's own \link cache::clear clear \endlink call. Implemention of this method should drop all it's knowledge about the
+         * keys and their usage and start from scratch.
+         *
+         * \see cache::clear
+         *
          */
         virtual void clear() =0;
         /*!
-         * \brief swap call helper 
-         *  
-         * Called by cache during it's own \link cache::swap swap \endlink call. Implementation of this method should swap it's data with the _p data 
-         * in some way. 
-         *  
-         * \param <_p>  Another policy of the same type as this policy cache is swapped with that of this policy. 
-         *  
-         * \throw <exception_invalid_policy> Thrown when the supplied policy have a wrong type or can't be swapped. 
-         *  
-         * \see cache::swap 
-         *  
+         * \brief swap call helper
+         *
+         * Called by cache during it's own \link cache::swap swap \endlink call. Implementation of this method should swap it's data with the _p data
+         * in some way.
+         *
+         * \param <_p>  Another policy of the same type as this policy cache is swapped with that of this policy.
+         *
+         * \throw <exception_invalid_policy> Thrown when the supplied policy have a wrong type or can't be swapped.
+         *
+         * \see cache::swap
+         *
          */
         virtual void swap(policy<Key,Allocator>& _p)=0;
 
         /*!
          * \brief Returns a key of the entry, that is expired by the policy and could be removed.
-         * 
-         * Called by cache, when it's out of space and need to find some. Usually before insertion, but we could not guarantee it. The implementation should 
+         *
+         * Called by cache, when it's out of space and need to find some. Usually before insertion, but we could not guarantee it. The implementation should
          *  make a decision, what key to expire this time, and return it, using wrapper, to the cache. It is allowed to not return any key, if the
          *  policy can't make a choice, that's why we have a to wrap a value.
          *  The \link stlcache::_victim wrapper \endlink is able to carry some optional value or be empty and provides some information, whether it
-         *  contains some data or not. 
-         * 
-         * \return wrapped optional expired key value 
-         *  
-         * \see cache::insert 
+         *  contains some data or not.
+         *
+         * \return wrapped optional expired key value
+         *
+         * \see cache::insert
          */
         virtual const _victim<Key> victim()  =0;
     };
@@ -187,15 +187,15 @@ namespace stlcache {
     };
 
     /*!
-     * \brief A 'random' expiration policy implementation 
-     *  
+     * \brief A 'random' expiration policy implementation
+     *
      * A implementation of the cache expiration policy, that expires entries randomly. It is fast and simple and always able to select a victim.
-     * 
+     *
      * \author chollya (5/19/2011)
      */
     struct policy_none {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_none_type<Key,Allocator> { 
+            struct bind : _policy_none_type<Key,Allocator> {
                 bind(const bind& x) : _policy_none_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_none_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy.hpp
+++ b/include/stlcache/policy.hpp
@@ -79,7 +79,7 @@ namespace stlcache {
          *  \see cache::insert
          *  
          */
-        virtual void insert(const Key& _k) throw(exception_invalid_key) =0;
+        virtual void insert(const Key& _k) =0;
         /*!
          * \brief handles deletion of a entry from the cache 
          *  
@@ -91,7 +91,7 @@ namespace stlcache {
          * \see cache::erase 
          * 
          */
-        virtual void remove(const Key& _k) throw() =0;
+        virtual void remove(const Key& _k) =0;
         /*!
          * \brief marks that the specified entry is used by cache
          *  
@@ -105,7 +105,7 @@ namespace stlcache {
          * \see cache::check 
          *  
          */
-        virtual void touch(const Key& _k) throw() =0;
+        virtual void touch(const Key& _k) =0;
         /*!
          * \brief clear call helper 
          *  
@@ -115,7 +115,7 @@ namespace stlcache {
          * \see cache::clear 
          *  
          */
-        virtual void clear() throw() =0;
+        virtual void clear() =0;
         /*!
          * \brief swap call helper 
          *  
@@ -129,7 +129,7 @@ namespace stlcache {
          * \see cache::swap 
          *  
          */
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy)=0;
+        virtual void swap(policy<Key,Allocator>& _p)=0;
 
         /*!
          * \brief Returns a key of the entry, that is expired by the policy and could be removed.
@@ -144,32 +144,32 @@ namespace stlcache {
          *  
          * \see cache::insert 
          */
-        virtual const _victim<Key> victim() throw()  =0;
+        virtual const _victim<Key> victim()  =0;
     };
 
     template <class Key, template <typename T> class Allocator> class _policy_none_type : public policy<Key,Allocator> {
         set<Key,less<Key>,Allocator<Key> > _entries;
     public:
-        _policy_none_type<Key,Allocator>& operator= ( const _policy_none_type<Key,Allocator>& x) throw() {
+        _policy_none_type<Key,Allocator>& operator= ( const _policy_none_type<Key,Allocator>& x) {
             this->_entries=x._entries;
             return *this;
         }
-        _policy_none_type(const _policy_none_type<Key,Allocator>& x) throw() {
+        _policy_none_type(const _policy_none_type<Key,Allocator>& x) {
             *this=x;
         }
-        _policy_none_type(const size_t& size ) throw() { }
+        _policy_none_type(const size_t& size ) { }
 
-        virtual void insert(const Key& _k) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k) {
             _entries.insert(_k);
         }
-        virtual void remove(const Key& _k) throw() {
+        virtual void remove(const Key& _k) {
             _entries.erase(_k);
         }
-        virtual void touch(const Key& _k) throw() { /* Not used here */  }
-        virtual void clear() throw() {
+        virtual void touch(const Key& _k) { /* Not used here */  }
+        virtual void clear() {
             _entries.clear();
         }
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {
+        virtual void swap(policy<Key,Allocator>& _p) {
             try {
                 _policy_none_type<Key,Allocator>& _pn=dynamic_cast<_policy_none_type<Key,Allocator>& >(_p);
                 _entries.swap(_pn._entries);
@@ -178,7 +178,7 @@ namespace stlcache {
             }
         }
 
-        virtual const _victim<Key> victim() throw() {
+        virtual const _victim<Key> victim() {
             if (_entries.rbegin()==_entries.rend()) {
                 return _victim<Key>();
             }

--- a/include/stlcache/policy_adaptive.hpp
+++ b/include/stlcache/policy_adaptive.hpp
@@ -28,7 +28,7 @@ namespace stlcache {
         set<Key,less<Key>,Allocator<Key> > b2Entries;
 
     public:
-        _policy_adaptive_type<Key,Allocator>& operator= ( const _policy_adaptive_type<Key,Allocator>& x) throw() {
+        _policy_adaptive_type<Key,Allocator>& operator= ( const _policy_adaptive_type<Key,Allocator>& x) {
             this->_size=x._size;
 
             this->T1=x.T1;
@@ -42,7 +42,7 @@ namespace stlcache {
 
             return *this;
         }
-        _policy_adaptive_type(const _policy_adaptive_type<Key,Allocator>& x) throw() : T1(x.T1),T2(x.T2),B1(x.B1),B2(x.B2) {
+        _policy_adaptive_type(const _policy_adaptive_type<Key,Allocator>& x) : T1(x.T1),T2(x.T2),B1(x.B1),B2(x.B2) {
             this->_size=x._size;
 
             this->t1Entries=x.t1Entries;
@@ -50,11 +50,11 @@ namespace stlcache {
             this->t2Entries=x.t2Entries;
             this->b2Entries=x.b2Entries;
         }
-        _policy_adaptive_type(const size_t& size ) throw() : T1(size),T2(size),B1(size),B2(size) { 
+        _policy_adaptive_type(const size_t& size ) : T1(size),T2(size),B1(size),B2(size) { 
             this->_size=size;
         }
 
-        virtual void insert(const Key& _k) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k) {
             if (b1Entries.find(_k)!=b1Entries.end()) {
                 //Check, whether we are outsized
                 b1Entries.erase(_k);
@@ -75,7 +75,7 @@ namespace stlcache {
                 T1.insert(_k);
             }
         }
-        virtual void remove(const Key& _k) throw() {
+        virtual void remove(const Key& _k) {
             if (t1Entries.find(_k)!=t1Entries.end()) {
                 B1.insert(_k);
                 b1Entries.insert(_k);
@@ -100,7 +100,7 @@ namespace stlcache {
                 T2.remove(_k);
             }
         }
-        virtual void touch(const Key& _k) throw() { 
+        virtual void touch(const Key& _k) { 
             if (t1Entries.find(_k)!=t1Entries.end()) {
                 t1Entries.erase(_k);
                 T1.remove(_k);
@@ -110,7 +110,7 @@ namespace stlcache {
                 T2.touch(_k);
             }
         }
-        virtual void clear() throw() {
+        virtual void clear() {
             T1.clear();
             t1Entries.clear();
             T2.clear();
@@ -120,7 +120,7 @@ namespace stlcache {
             B2.clear();
             b2Entries.clear();
         }
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {
+        virtual void swap(policy<Key,Allocator>& _p) {
             try {
                 _policy_adaptive_type<Key,Allocator>& _pn=dynamic_cast<_policy_adaptive_type<Key,Allocator>& >(_p);
                 T1.swap(_pn.T1);
@@ -136,7 +136,7 @@ namespace stlcache {
             }
         }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
             if (t1Entries.size()>t2Entries.size()) {
                 return T1.victim();
             } else {

--- a/include/stlcache/policy_adaptive.hpp
+++ b/include/stlcache/policy_adaptive.hpp
@@ -50,7 +50,7 @@ namespace stlcache {
             this->t2Entries=x.t2Entries;
             this->b2Entries=x.b2Entries;
         }
-        _policy_adaptive_type(const size_t& size ) : T1(size),T2(size),B1(size),B2(size) { 
+        _policy_adaptive_type(const size_t& size ) : T1(size),T2(size),B1(size),B2(size) {
             this->_size=size;
         }
 
@@ -100,7 +100,7 @@ namespace stlcache {
                 T2.remove(_k);
             }
         }
-        virtual void touch(const Key& _k) { 
+        virtual void touch(const Key& _k) {
             if (t1Entries.find(_k)!=t1Entries.end()) {
                 t1Entries.erase(_k);
                 T1.remove(_k);
@@ -147,19 +147,19 @@ namespace stlcache {
 
     /*!
      * \brief A 'Adaptive replacement' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Adaptive_replacement_cache">'Adaptive replacement'</a> cache algorithm. 
-     *  
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Adaptive_replacement_cache">'Adaptive replacement'</a> cache algorithm.
+     *
      * The adaptive cache algorithm is balancing between internal LRU and LFU caches, trying to adapt to the external expectations on it.
-     *    
-     * \link cache::touch Touching \endlink the entry decreases item's expiration probability. This policy is always able to expire any amount of entries.     
-     *  
-     * No additional configuration is required. 
-     *  
+     *
+     * \link cache::touch Touching \endlink the entry decreases item's expiration probability. This policy is always able to expire any amount of entries.
+     *
+     * No additional configuration is required.
+     *
      */
     struct policy_adaptive {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_adaptive_type<Key,Allocator> { 
+            struct bind : _policy_adaptive_type<Key,Allocator> {
                 bind(const bind& x) : _policy_adaptive_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_adaptive_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_lfu.hpp
+++ b/include/stlcache/policy_lfu.hpp
@@ -30,27 +30,27 @@ namespace stlcache {
         
 
     public:
-        _policy_lfu_type<Key,Allocator>& operator= ( const _policy_lfu_type<Key,Allocator>& x) throw() {
+        _policy_lfu_type<Key,Allocator>& operator= ( const _policy_lfu_type<Key,Allocator>& x) {
             this->_entries=x._entries;
             this->_backEntries=x._backEntries;
             return *this;
         }
-        _policy_lfu_type(const _policy_lfu_type<Key,Allocator>& x) throw() {
+        _policy_lfu_type(const _policy_lfu_type<Key,Allocator>& x) {
             *this=x;
         }
-        _policy_lfu_type(const size_t& size ) throw() { }
+        _policy_lfu_type(const size_t& size ) { }
 
-        virtual void insert(const Key& _k,unsigned int refCount) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k,unsigned int refCount) {
             //1 - is initial reference value
             entriesIterator newEntryIter = _entries.insert(entriesPair(refCount,_k));
             _backEntries.insert(backEntriesPair(_k,newEntryIter));
         }
-        virtual void insert(const Key& _k) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k) {
             //1 - is initial reference value
             this->insert(_k,1);
         }
 
-        virtual void remove(const Key& _k) throw() {
+        virtual void remove(const Key& _k) {
             backEntriesIterator backIter = _backEntries.find(_k);
             if (backIter==_backEntries.end()) {
                 return;
@@ -59,7 +59,7 @@ namespace stlcache {
             _entries.erase(backIter->second);
             _backEntries.erase(_k);
         }
-        virtual void touch(const Key& _k) throw() { 
+        virtual void touch(const Key& _k) { 
             backEntriesIterator backIter = _backEntries.find(_k);
             if (backIter==_backEntries.end()) {
                 return;
@@ -71,11 +71,11 @@ namespace stlcache {
             entriesIterator entryIter=_entries.insert(entriesPair(refCount+1,_k));
             backIter->second=entryIter;
         }
-        virtual void clear() throw() {
+        virtual void clear() {
             _entries.clear();
             _backEntries.clear();
         }
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {
+        virtual void swap(policy<Key,Allocator>& _p) {
             try {
                 _policy_lfu_type<Key,Allocator>& _pn=dynamic_cast<_policy_lfu_type<Key,Allocator>& >(_p);
                 _entries.swap(_pn._entries);
@@ -85,7 +85,7 @@ namespace stlcache {
             }
         }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
             if (_entries.begin()==_entries.end()) {
                 return _victim<Key>();
             }
@@ -97,7 +97,7 @@ namespace stlcache {
         const entriesType& entries() const {
             return this->_entries;
         }
-        virtual unsigned long long untouch(const Key& _k) throw() { 
+        virtual unsigned long long untouch(const Key& _k) { 
             backEntriesIterator backIter = _backEntries.find(_k);
             if (backIter==_backEntries.end()) {
                 return 0;

--- a/include/stlcache/policy_lfu.hpp
+++ b/include/stlcache/policy_lfu.hpp
@@ -27,7 +27,7 @@ namespace stlcache {
         typedef map<Key,entriesIterator,less<Key>,Allocator<backEntriesPair> > backEntriesType;
         backEntriesType _backEntries;
         typedef typename backEntriesType::iterator backEntriesIterator;
-        
+
 
     public:
         _policy_lfu_type<Key,Allocator>& operator= ( const _policy_lfu_type<Key,Allocator>& x) {
@@ -59,14 +59,14 @@ namespace stlcache {
             _entries.erase(backIter->second);
             _backEntries.erase(_k);
         }
-        virtual void touch(const Key& _k) { 
+        virtual void touch(const Key& _k) {
             backEntriesIterator backIter = _backEntries.find(_k);
             if (backIter==_backEntries.end()) {
                 return;
             }
 
             unsigned int refCount=backIter->second->first;
-            
+
             _entries.erase(backIter->second);
             entriesIterator entryIter=_entries.insert(entriesPair(refCount+1,_k));
             backIter->second=entryIter;
@@ -97,7 +97,7 @@ namespace stlcache {
         const entriesType& entries() const {
             return this->_entries;
         }
-        virtual unsigned long long untouch(const Key& _k) { 
+        virtual unsigned long long untouch(const Key& _k) {
             backEntriesIterator backIter = _backEntries.find(_k);
             if (backIter==_backEntries.end()) {
                 return 0;
@@ -120,24 +120,24 @@ namespace stlcache {
 
     /*!
      * \brief A 'Least Frequently Used' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'Least Frequently Used'</a> cache algorithm. 
-     *  
-     * The LFU policy tracks how many times entry was used and selects entries with the smallest usage count for expiration. There is a big difference 
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'Least Frequently Used'</a> cache algorithm.
+     *
+     * The LFU policy tracks how many times entry was used and selects entries with the smallest usage count for expiration. There is a big difference
      * between LFU and \link stlcache::policy_lru LRU \endlink policies - the LRU policy only tracks the fact of entry usage, but the LFU also takes in
-     * the account the number of entry usages. 
-     * \link cache::touch Touching \endlink the entry greatly decreases item's expiration probability. This policy is always able to expire any amount of entries. 
-     *  
-     * No additional configuration is required. 
-     *  
+     * the account the number of entry usages.
+     * \link cache::touch Touching \endlink the entry greatly decreases item's expiration probability. This policy is always able to expire any amount of entries.
+     *
+     * No additional configuration is required.
+     *
      * \see policy_lfustar
-     * \see policy_lfuaging 
-     * \see policy_lfuagingstar 
-     *  
+     * \see policy_lfuaging
+     * \see policy_lfuagingstar
+     *
      */
     struct policy_lfu {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_lfu_type<Key,Allocator> { 
+            struct bind : _policy_lfu_type<Key,Allocator> {
                 bind(const bind& x) : _policy_lfu_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_lfu_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_lfuaging.hpp
+++ b/include/stlcache/policy_lfuaging.hpp
@@ -23,39 +23,39 @@ namespace stlcache {
         time_t _oldestEntry;
         time_t age;
     public:
-        _policy_lfuaging_type<Age,Key,Allocator>& operator= ( const _policy_lfuaging_type<Age,Key,Allocator>& x) throw() {
+        _policy_lfuaging_type<Age,Key,Allocator>& operator= ( const _policy_lfuaging_type<Age,Key,Allocator>& x) {
             _policy_lfu_type<Key,Allocator>::operator=(x);
             this->_timeKeeper=x._timeKeeper;
             this->_oldestEntry=x._oldestEntry;
             this->age=x.age;
             return *this;
         }
-        _policy_lfuaging_type(const _policy_lfuaging_type<Age,Key,Allocator>& x)  throw() : _policy_lfu_type<Key,Allocator>(x) {
+        _policy_lfuaging_type(const _policy_lfuaging_type<Age,Key,Allocator>& x)  : _policy_lfu_type<Key,Allocator>(x) {
             *this=x;
         }
-        _policy_lfuaging_type(const size_t& size ) throw() : _policy_lfu_type<Key,Allocator>(size) { 
+        _policy_lfuaging_type(const size_t& size ) : _policy_lfu_type<Key,Allocator>(size) { 
             this->age=Age;
             this->_oldestEntry=time(NULL);
         }
 
-        virtual void insert(const Key& _k) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k) {
             _policy_lfu_type<Key,Allocator>::insert(_k);
             _timeKeeper.insert(std::pair<Key,time_t>(_k,time(NULL))); //Because touch always increases the refcount, so it couldn't be 1 after touch
         }
-        virtual void remove(const Key& _k) throw() {
+        virtual void remove(const Key& _k) {
             _policy_lfu_type<Key,Allocator>::remove(_k);
             _timeKeeper.erase(_k);
         }
-        virtual void touch(const Key& _k) throw() { 
+        virtual void touch(const Key& _k) { 
             _policy_lfu_type<Key,Allocator>::touch(_k);
             _timeKeeper.erase(_k);
             _timeKeeper.insert(std::pair<Key,time_t>(_k,time(NULL))); //Because touch always increases the refcount, so it couldn't be 1 after touch
         }   
-        virtual void clear() throw() {
+        virtual void clear() {
             _policy_lfu_type<Key,Allocator>::clear();
             _timeKeeper.clear();
         }
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {
+        virtual void swap(policy<Key,Allocator>& _p) {
             try {
                 _policy_lfuaging_type<Age,Key,Allocator>& _pn=dynamic_cast<_policy_lfuaging_type<Age,Key,Allocator>& >(_p);
                 _timeKeeper.swap(_pn._timeKeeper);
@@ -73,7 +73,7 @@ namespace stlcache {
                 throw exception_invalid_policy("Attempted to swap incompatible policies");
             }
         }
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
 			this->expire();
             return _policy_lfu_type<Key,Allocator>::victim();
         }

--- a/include/stlcache/policy_lfuaging.hpp
+++ b/include/stlcache/policy_lfuaging.hpp
@@ -33,7 +33,7 @@ namespace stlcache {
         _policy_lfuaging_type(const _policy_lfuaging_type<Age,Key,Allocator>& x)  : _policy_lfu_type<Key,Allocator>(x) {
             *this=x;
         }
-        _policy_lfuaging_type(const size_t& size ) : _policy_lfu_type<Key,Allocator>(size) { 
+        _policy_lfuaging_type(const size_t& size ) : _policy_lfu_type<Key,Allocator>(size) {
             this->age=Age;
             this->_oldestEntry=time(NULL);
         }
@@ -46,11 +46,11 @@ namespace stlcache {
             _policy_lfu_type<Key,Allocator>::remove(_k);
             _timeKeeper.erase(_k);
         }
-        virtual void touch(const Key& _k) { 
+        virtual void touch(const Key& _k) {
             _policy_lfu_type<Key,Allocator>::touch(_k);
             _timeKeeper.erase(_k);
             _timeKeeper.insert(std::pair<Key,time_t>(_k,time(NULL))); //Because touch always increases the refcount, so it couldn't be 1 after touch
-        }   
+        }
         virtual void clear() {
             _policy_lfu_type<Key,Allocator>::clear();
             _timeKeeper.clear();
@@ -92,7 +92,7 @@ namespace stlcache {
                         Key itCopy=(*it).first;
                         unsigned long long currentRef=this->untouch((*it).first);
                         toErase.push_front(itCopy);
-                        
+
                         if (currentRef>1) {
                             toInsert.push_front(itCopy);
                         }
@@ -117,30 +117,30 @@ namespace stlcache {
 
     /*!
      * \brief A 'LFU-Aging' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'LFU-Aging'</a> cache algorithm. 
-     *  
-     * A modified \link stlcache::policy_lfu LFU \endlink policy implementation, that allows the reference count to move in both directions. 
-     * Opposed to the usual \link stlcache::policy_lfu LFU \endlink, that allows only growth of the entries references counts, the LFU-Aging 
-     * also decreases the reference count of an entry, that was put into the cache some time ago. 
-     *  
-     * So, when you put an entry into the cache and start using it, entry's reference count will increase on every usage. 
-     * At the same time, the LFU-Aging algorithm will be applying the 'aging interval' on the entries in cache and 
-     * decrease entry's reference count every time. So the entries, that were popular in the past, but not needed right now, will 
-     * get a better chance to get out of the cache, then with usual LFU algorithm. 
-     *  
-     * \link cache::touch Touching \endlink the entry may not change item's expiration probability. This policy is always able to expire any amount of entries. 
-     *  
-     * The policy must be configured with the length of a aging interval: 
-     *  
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'LFU-Aging'</a> cache algorithm.
+     *
+     * A modified \link stlcache::policy_lfu LFU \endlink policy implementation, that allows the reference count to move in both directions.
+     * Opposed to the usual \link stlcache::policy_lfu LFU \endlink, that allows only growth of the entries references counts, the LFU-Aging
+     * also decreases the reference count of an entry, that was put into the cache some time ago.
+     *
+     * So, when you put an entry into the cache and start using it, entry's reference count will increase on every usage.
+     * At the same time, the LFU-Aging algorithm will be applying the 'aging interval' on the entries in cache and
+     * decrease entry's reference count every time. So the entries, that were popular in the past, but not needed right now, will
+     * get a better chance to get out of the cache, then with usual LFU algorithm.
+     *
+     * \link cache::touch Touching \endlink the entry may not change item's expiration probability. This policy is always able to expire any amount of entries.
+     *
+     * The policy must be configured with the length of a aging interval:
+     *
      * \tparam <Age>  aging interval in seconds
-     *  
-     * \see policy_lfu 
-     * \see policu_lfuagingstar 
+     *
+     * \see policy_lfu
+     * \see policu_lfuagingstar
      */
     template <time_t Age> struct policy_lfuaging {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_lfuaging_type<Age,Key,Allocator> { 
+            struct bind : _policy_lfuaging_type<Age,Key,Allocator> {
                 bind(const bind& x) : _policy_lfuaging_type<Age,Key,Allocator>(x),_policy_lfu_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_lfuaging_type<Age,Key,Allocator>(size),_policy_lfu_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_lfuagingstar.hpp
+++ b/include/stlcache/policy_lfuagingstar.hpp
@@ -25,9 +25,9 @@ using namespace std;
 namespace stlcache {
     template <time_t Age,class Key,template <typename T> class Allocator> class _policy_lfuagingstar_type : public virtual _policy_lfuaging_type<Age,Key,Allocator>, public virtual _policy_lfustar_type<Key,Allocator> {
     public:
-        _policy_lfuagingstar_type(const size_t& size ) throw() : _policy_lfuaging_type<Age,Key,Allocator>(size), _policy_lfustar_type<Key,Allocator>(size),_policy_lfu_type<Key,Allocator>(size) { }
+        _policy_lfuagingstar_type(const size_t& size ) : _policy_lfuaging_type<Age,Key,Allocator>(size), _policy_lfustar_type<Key,Allocator>(size),_policy_lfu_type<Key,Allocator>(size) { }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
 			_policy_lfuaging_type<Age,Key,Allocator>::expire();
             return _policy_lfustar_type<Key,Allocator>::victim();
         }

--- a/include/stlcache/policy_lfuagingstar.hpp
+++ b/include/stlcache/policy_lfuagingstar.hpp
@@ -34,28 +34,28 @@ namespace stlcache {
     };
         /*!
      * \brief A 'LFU*-Aging' policy
-     * 
+     *
      * Combination of \link stlcache::policy_lfustar LFU* \endlink and \link stlcache::policy_lfuaging LFU-Aging \endlink policies.
-     *  
-     * It is mostly the \link stlcache::policy_lfustar LFU* \endlink with expiration of entries. Primary difference with    
-     * the \link stlcache::policy_lfustar LFU* \endlink is that the entries, with reference count more then 1, will have    
+     *
+     * It is mostly the \link stlcache::policy_lfustar LFU* \endlink with expiration of entries. Primary difference with
+     * the \link stlcache::policy_lfustar LFU* \endlink is that the entries, with reference count more then 1, will have
      *  a chance to expire, after several applies of the aging interval.
-     *  
-     * \link cache::touch Touching \endlink the entry may not change item's expiration probability. The LFU*-Aging policy may not be able 
-     * to find a excessive entry, when cache is full, so the \link cache::insert insert call \endlink may throw a \link stlcache::exception_cache_full 
+     *
+     * \link cache::touch Touching \endlink the entry may not change item's expiration probability. The LFU*-Aging policy may not be able
+     * to find a excessive entry, when cache is full, so the \link cache::insert insert call \endlink may throw a \link stlcache::exception_cache_full
      * cache full \endlink exception.
-     *  
-     * The policy must be configured with the length of a aging interval: 
-     *  
+     *
+     * The policy must be configured with the length of a aging interval:
+     *
      * \tparam <Age>  aging interval in seconds
-     *  
-     * \see policy_lfu 
-     * \see policu_lfuaging 
+     *
+     * \see policy_lfu
+     * \see policu_lfuaging
      * \see policu_lfustar
      */
     template <time_t Age> struct policy_lfuagingstar {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_lfuagingstar_type<Age,Key,Allocator> { 
+            struct bind : _policy_lfuagingstar_type<Age,Key,Allocator> {
                 bind(const bind& x) : _policy_lfuagingstar_type<Age,Key,Allocator>(x),_policy_lfuaging_type<Age,Key,Allocator>(x),_policy_lfustar_type<Key,Allocator>(x),_policy_lfu_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_lfuagingstar_type<Age,Key,Allocator>(size),_policy_lfuaging_type<Age,Key,Allocator>(size),_policy_lfustar_type<Key,Allocator>(size),_policy_lfu_type<Key,Allocator>(size)  { }
             };

--- a/include/stlcache/policy_lfustar.hpp
+++ b/include/stlcache/policy_lfustar.hpp
@@ -35,31 +35,31 @@ namespace stlcache {
     };
     /*!
      * \brief A 'LFU*' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'LFU*'</a> cache algorithm. 
-     *  
-     * A modified \link stlcache::policy_lfu LFU \endlink policy implementation, that expires onty items with usage count equal to 1. 
-     * In other words, this policy still tracks, how much times the entry were used, but selects for the expiration only those entries, that 
-     * was touched not more, then one time. 
-     *  
-     * For example, when you put a entry into the cache and then never use it 
-     * (either by \link cache::fetch fetching \endlink or  \link cache::touch touching \endlink it), the entry may be expired sometime. 
-     * If you only \link cache::touch touch \endlink of \link cache::fetch fetch \endlink the item once, it still will be a candidate for expiration. 
-     * But. If you use there entry one more time (at least tow times), it will be never removed from the cache automatically and must be 
-     * erased by hand. 
-     *   
-     * So, \link cache::touch Touching \endlink the entry twice makes entry unexpirable. Because of this, the LFU* policy may not be able 
-     * to find a excessive entry, when cache is full, so the \link cache::insert insert call \endlink may throw a \link stlcache::exception_cache_full 
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Least_frequently_used">'LFU*'</a> cache algorithm.
+     *
+     * A modified \link stlcache::policy_lfu LFU \endlink policy implementation, that expires onty items with usage count equal to 1.
+     * In other words, this policy still tracks, how much times the entry were used, but selects for the expiration only those entries, that
+     * was touched not more, then one time.
+     *
+     * For example, when you put a entry into the cache and then never use it
+     * (either by \link cache::fetch fetching \endlink or  \link cache::touch touching \endlink it), the entry may be expired sometime.
+     * If you only \link cache::touch touch \endlink of \link cache::fetch fetch \endlink the item once, it still will be a candidate for expiration.
+     * But. If you use there entry one more time (at least tow times), it will be never removed from the cache automatically and must be
+     * erased by hand.
+     *
+     * So, \link cache::touch Touching \endlink the entry twice makes entry unexpirable. Because of this, the LFU* policy may not be able
+     * to find a excessive entry, when cache is full, so the \link cache::insert insert call \endlink may throw a \link stlcache::exception_cache_full
      * cache full \endlink exception.
-     *  
-     * No additional configuration is required. 
-     *  
-     * \see policy_lfu 
-     * \see policu_lfuagingstar 
+     *
+     * No additional configuration is required.
+     *
+     * \see policy_lfu
+     * \see policu_lfuagingstar
      */
     struct policy_lfustar {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_lfustar_type<Key,Allocator> { 
+            struct bind : _policy_lfustar_type<Key,Allocator> {
                 bind(const bind& x) : _policy_lfustar_type<Key,Allocator>(x),_policy_lfu_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_lfustar_type<Key,Allocator>(size),_policy_lfu_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_lfustar.hpp
+++ b/include/stlcache/policy_lfustar.hpp
@@ -19,10 +19,10 @@ namespace stlcache {
     template <class Key,template <typename T> class Allocator> class _policy_lfustar_type : public virtual _policy_lfu_type<Key,Allocator> {
         typedef set<Key,less<Key>,Allocator<Key> > keySet;
     public:
-        _policy_lfustar_type(const size_t& size ) throw() : _policy_lfu_type<Key,Allocator>(size) { }
-        _policy_lfustar_type(const _policy_lfustar_type& x ) throw() : _policy_lfu_type<Key,Allocator>(x) { }
+        _policy_lfustar_type(const size_t& size ) : _policy_lfu_type<Key,Allocator>(size) { }
+        _policy_lfustar_type(const _policy_lfustar_type& x ) : _policy_lfu_type<Key,Allocator>(x) { }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
             //LFU* only operates on entries with references count equal to 1
             typedef typename _policy_lfu_type<Key,Allocator>::entriesType::const_iterator entriesIterType;
             entriesIterType entriesIter = this->entries().find(1);

--- a/include/stlcache/policy_lru.hpp
+++ b/include/stlcache/policy_lru.hpp
@@ -24,6 +24,10 @@ namespace stlcache {
     public:
         _policy_lru_type<Key,Allocator>& operator= ( const _policy_lru_type<Key,Allocator>& x) {
             this->_entries=x._entries;
+            _entriesMap.clear();
+            for(entriesIterator entryIter=_entries.begin();entryIter!=_entries.end();++entryIter) {
+              _entriesMap.insert(pair<Key,entriesIterator>(*entryIter,entryIter));
+            }
             return *this;
         }
         _policy_lru_type(const _policy_lru_type<Key,Allocator>& x) {
@@ -54,6 +58,7 @@ namespace stlcache {
         }
         virtual void clear() {
             _entries.clear();
+            _entriesMap.clear();
         }
         virtual void swap(policy<Key,Allocator>& _p) {
             try {

--- a/include/stlcache/policy_lru.hpp
+++ b/include/stlcache/policy_lru.hpp
@@ -43,7 +43,7 @@ namespace stlcache {
             _entries.erase(mapIter->second);
             _entriesMap.erase(mapIter);
         }
-        virtual void touch(const Key& _k) { 
+        virtual void touch(const Key& _k) {
             entriesMapIterator mapIter = _entriesMap.find(_k);
             if (mapIter==_entriesMap.end()) {
                 return;
@@ -75,17 +75,17 @@ namespace stlcache {
 
     /*!
      * \brief A 'Least Recently Used' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used">'Least Recently Used'</a> cache expiration algorithm. 
-     *  
-     * The LRU policy tracks the usage of items and moves the recently used items to the front of the items stack and select items for the expiration from the end 
-     * of the stack. \link cache::touch Touching \endlink the entry decreases item's expiration probability. This policy is always able to expire any amount of entries. 
-     *  
-     * No additional configuration is required. 
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used">'Least Recently Used'</a> cache expiration algorithm.
+     *
+     * The LRU policy tracks the usage of items and moves the recently used items to the front of the items stack and select items for the expiration from the end
+     * of the stack. \link cache::touch Touching \endlink the entry decreases item's expiration probability. This policy is always able to expire any amount of entries.
+     *
+     * No additional configuration is required.
      */
     struct policy_lru {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_lru_type<Key,Allocator> { 
+            struct bind : _policy_lru_type<Key,Allocator> {
                 bind(const bind& x) : _policy_lru_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_lru_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_lru.hpp
+++ b/include/stlcache/policy_lru.hpp
@@ -22,20 +22,20 @@ namespace stlcache {
         map<Key,entriesIterator,less<Key>,Allocator<pair<Key,entriesIterator> > > _entriesMap;
         typedef typename map<Key,entriesIterator,less<Key>,Allocator<pair<Key,entriesIterator> > >::iterator entriesMapIterator;
     public:
-        _policy_lru_type<Key,Allocator>& operator= ( const _policy_lru_type<Key,Allocator>& x) throw() {
+        _policy_lru_type<Key,Allocator>& operator= ( const _policy_lru_type<Key,Allocator>& x) {
             this->_entries=x._entries;
             return *this;
         }
-        _policy_lru_type(const _policy_lru_type<Key,Allocator>& x) throw() {
+        _policy_lru_type(const _policy_lru_type<Key,Allocator>& x) {
             *this=x;
         }
-        _policy_lru_type(const size_t& size ) throw() { }
+        _policy_lru_type(const size_t& size ) { }
 
-        virtual void insert(const Key& _k) throw(exception_invalid_key) {
+        virtual void insert(const Key& _k) {
             entriesIterator entryIter = _entries.insert(_entries.begin(),_k);
             _entriesMap.insert(pair<Key,entriesIterator>(_k,entryIter));
         }
-        virtual void remove(const Key& _k) throw() {
+        virtual void remove(const Key& _k) {
             entriesMapIterator mapIter = _entriesMap.find(_k);
             if (mapIter==_entriesMap.end()) {
                 return;
@@ -43,7 +43,7 @@ namespace stlcache {
             _entries.erase(mapIter->second);
             _entriesMap.erase(mapIter);
         }
-        virtual void touch(const Key& _k) throw() { 
+        virtual void touch(const Key& _k) { 
             entriesMapIterator mapIter = _entriesMap.find(_k);
             if (mapIter==_entriesMap.end()) {
                 return;
@@ -52,10 +52,10 @@ namespace stlcache {
             entriesIterator entryIter = _entries.insert(_entries.begin(),_k);
             mapIter->second=entryIter;
         }
-        virtual void clear() throw() {
+        virtual void clear() {
             _entries.clear();
         }
-        virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {
+        virtual void swap(policy<Key,Allocator>& _p) {
             try {
                 _policy_lru_type<Key,Allocator>& _pn=dynamic_cast<_policy_lru_type<Key,Allocator>& >(_p);
                 _entries.swap(_pn._entries);
@@ -65,7 +65,7 @@ namespace stlcache {
             }
         }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
             return _victim<Key>(_entries.back());
         }
 

--- a/include/stlcache/policy_mru.hpp
+++ b/include/stlcache/policy_mru.hpp
@@ -27,18 +27,18 @@ namespace stlcache {
 
     /*!
      * \brief A 'Most Recently Used' policy
-     * 
-     * Implements <a href="http://en.wikipedia.org/wiki/Cache_algorithms#Most_Recently_Used">'Most Recently Used'</a> cache expiration algorithm. 
-     *  
-     * The MRU policy tracks the usage of items and moves the recently used items to the front of the items stack 
-     * and selects items for the expiration from the front of the stack too 
-     * \link cache::touch Touching \endlink the entry makes it a candidate to be expired. This policy is always able to expire any amount of entries. 
-     *  
-     * No additional configuration is required. 
+     *
+     * Implements <a href="http://en.wikipedia.org/wiki/Cache_algorithms#Most_Recently_Used">'Most Recently Used'</a> cache expiration algorithm.
+     *
+     * The MRU policy tracks the usage of items and moves the recently used items to the front of the items stack
+     * and selects items for the expiration from the front of the stack too
+     * \link cache::touch Touching \endlink the entry makes it a candidate to be expired. This policy is always able to expire any amount of entries.
+     *
+     * No additional configuration is required.
      */
     struct policy_mru {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_mru_type<Key,Allocator> { 
+            struct bind : _policy_mru_type<Key,Allocator> {
                 bind(const bind& x) : _policy_mru_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_mru_type<Key,Allocator>(size) { }
             };

--- a/include/stlcache/policy_mru.hpp
+++ b/include/stlcache/policy_mru.hpp
@@ -17,9 +17,9 @@ using namespace std;
 namespace stlcache {
     template <class Key,template <typename T> class Allocator> class _policy_mru_type : public _policy_lru_type<Key,Allocator> {
     public:
-        _policy_mru_type(const size_t& size ) throw() : _policy_lru_type<Key,Allocator>(size) { }
+        _policy_mru_type(const size_t& size ) : _policy_lru_type<Key,Allocator>(size) { }
 
-        virtual const _victim<Key> victim() throw()  {
+        virtual const _victim<Key> victim()  {
             return _victim<Key>(this->entries().front());
         }
     };

--- a/include/stlcache/stlcache.hpp
+++ b/include/stlcache/stlcache.hpp
@@ -203,12 +203,12 @@ namespace stlcache {
      \code
         template <class Key,template <typename T> class Allocator> class policy {
             public:
-            virtual void insert(const Key& _k) throw(exception_invalid_key) =0;
-            virtual void remove(const Key& _k) throw() =0;
-            virtual void touch(const Key& _k) throw() =0;
-            virtual void clear() throw() =0;
-            virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy)=0;
-            virtual const _victim<Key> victim() throw()  =0;
+            virtual void insert(const Key& _k) =0;
+            virtual void remove(const Key& _k) =0;
+            virtual void touch(const Key& _k) =0;
+            virtual void clear() =0;
+            virtual void swap(policy<Key,Allocator>& _p)=0;
+            virtual const _victim<Key> victim()  =0;
         };     
      \endcode
      
@@ -220,17 +220,17 @@ namespace stlcache {
      \code
         template <class Key, template <typename T> class Allocator> class _policy_none_type : public policy<Key,Allocator> {
         public:
-            _policy_none_type<Key,Allocator>& operator= ( const _policy_none_type<Key,Allocator>& x) throw() { }
-            _policy_none_type(const _policy_none_type<Key,Allocator>& x) throw() {}
-            _policy_none_type(const size_t& size ) throw() { }
+            _policy_none_type<Key,Allocator>& operator= ( const _policy_none_type<Key,Allocator>& x) { }
+            _policy_none_type(const _policy_none_type<Key,Allocator>& x) {}
+            _policy_none_type(const size_t& size ) { }
 
-            virtual void insert(const Key& _k) throw(exception_invalid_key) {}
-            virtual void remove(const Key& _k) throw() {}
-            virtual void touch(const Key& _k) throw() {}
-            virtual void clear() throw() {}
-            virtual void swap(policy<Key,Allocator>& _p) throw(exception_invalid_policy) {}
+            virtual void insert(const Key& _k) {}
+            virtual void remove(const Key& _k) {}
+            virtual void touch(const Key& _k) {}
+            virtual void clear() {}
+            virtual void swap(policy<Key,Allocator>& _p) {}
 
-            virtual const _victim<Key> victim() throw() {}
+            virtual const _victim<Key> victim() {}
         };
      \endcode
      
@@ -356,7 +356,7 @@ namespace stlcache {
           *
           *  \return The allocator object of type Allocator<pair<const Key, Data> >.                
           */
-        allocator_type get_allocator() const throw() {
+        allocator_type get_allocator() const {
             return _storage.get_allocator();
         }
 
@@ -373,7 +373,7 @@ namespace stlcache {
           *  \see check
           *  
           */        
-        size_type count ( const key_type& x ) const throw() {
+        size_type count ( const key_type& x ) const {
             return _storage.count(x);
         }
 
@@ -383,7 +383,7 @@ namespace stlcache {
          *  
          *   \return The value comparison object of type value_compare, defined as described above.
          */
-        value_compare value_comp ( ) const throw() {
+        value_compare value_comp ( ) const {
             return _storage.value_comp();
         }
 
@@ -398,7 +398,7 @@ namespace stlcache {
           *
           *  \return The key comparison object of type key_compare, defined to Compare, which is the fourth template parameter in the map class template.
           */
-        key_compare key_comp ( ) const throw() {
+        key_compare key_comp ( ) const {
             return _storage.key_comp();
         }
 
@@ -413,7 +413,7 @@ namespace stlcache {
           *  
           *   \see size
           */
-        bool empty() const throw() {
+        bool empty() const {
             return _storage.empty();
         }
         //@}
@@ -431,7 +431,7 @@ namespace stlcache {
          * \see empty 
          *  
          */
-        void clear() throw() {
+        void clear() {
             _storage.clear();
             _policy->clear();
             this->_currEntries=0;
@@ -449,7 +449,7 @@ namespace stlcache {
          *  
          * \see cache::operator= 
          */
-        void swap ( cache<Key,Data,Policy,Compare,Allocator>& mp ) throw(exception_invalid_policy) {
+        void swap ( cache<Key,Data,Policy,Compare,Allocator>& mp ) {
             _storage.swap(mp._storage);
             _policy->swap(*mp._policy);
 
@@ -471,7 +471,7 @@ namespace stlcache {
          *  
          * \return 1 when entry is removed (ie number of removed emtries, which is always 1, as keys are unique) or zero when nothing was done. 
          */
-        size_type erase ( const key_type& x ) throw() {
+        size_type erase ( const key_type& x ) {
             size_type ret=_storage.erase(x);
             _policy->remove(x);
 
@@ -492,7 +492,7 @@ namespace stlcache {
          *  
          * \return true if the new elemented was inserted or false if an element with the same key existed. 
          */
-        bool insert(Key _k, Data _d) throw(exception_cache_full,exception_invalid_key) {
+        bool insert(Key _k, Data _d) {
             while (this->_currEntries >= this->_maxEntries) {
                 _victim<Key> victim=_policy->victim();
                 if (!victim) {
@@ -522,7 +522,7 @@ namespace stlcache {
          *  
          * \see size 
          */
-        size_type max_size() const throw() {
+        size_type max_size() const {
             return this->_maxEntries;
         }
 
@@ -535,7 +535,7 @@ namespace stlcache {
           *  \see empty
           *  \see clear
           */        
-        size_type size() const throw() {
+        size_type size() const {
             assert(this->_currEntries==_storage.size());
             return this->_currEntries;
         }
@@ -554,7 +554,7 @@ namespace stlcache {
          *  
          * \see check 
          */
-        const Data& fetch(const Key& _k) throw(exception_invalid_key) {
+        const Data& fetch(const Key& _k) {
             if (!check(_k)) {
                 throw exception_invalid_key("Key is not in cache",_k);
             }
@@ -573,7 +573,7 @@ namespace stlcache {
          *  
          * \see count 
          */
-        const bool check(const Key& _k) throw() {
+        const bool check(const Key& _k) {
             _policy->touch(_k);
             return _storage.count(_k)==1;
         }
@@ -587,7 +587,7 @@ namespace stlcache {
          *  \param _k key to touch
          *  
          */
-        void touch(const Key& _k) throw() {
+        void touch(const Key& _k) {
             _policy->touch(_k);
         }
         //@}
@@ -606,7 +606,7 @@ namespace stlcache {
          *  
          * \see swap 
          */
-        cache<Key,Data,Policy,Compare,Allocator>& operator= ( const cache<Key,Data,Policy,Compare,Allocator>& x) throw() {
+        cache<Key,Data,Policy,Compare,Allocator>& operator= ( const cache<Key,Data,Policy,Compare,Allocator>& x) {
             this->_storage=x._storage;
             this->_maxEntries=x._maxEntries;
             this->_currEntries=this->_storage.size();
@@ -624,7 +624,7 @@ namespace stlcache {
          *  
          *  \param <x> a cache object with the same template parameters 
          */
-        cache(const cache<Key,Data,Policy,Compare,Allocator>& x) throw() {
+        cache(const cache<Key,Data,Policy,Compare,Allocator>& x) {
             *this=x;
         }
         /*!
@@ -637,7 +637,7 @@ namespace stlcache {
          * \param <comp> Comparator object, compatible with Compare type. Defaults to Compare() 
          * 
          */
-        explicit cache(const size_type size, const Compare& comp = Compare()) throw() {
+        explicit cache(const size_type size, const Compare& comp = Compare()) {
             this->_storage=storageType(comp, Allocator<pair<const Key, Data> >());
             this->_maxEntries=size;
             this->_currEntries=0;

--- a/include/stlcache/stlcache.hpp
+++ b/include/stlcache/stlcache.hpp
@@ -28,49 +28,49 @@ using namespace std;
 
 namespace stlcache {
 
-    /*! 
+    /*!
       \mainpage STL::Cache - in-memory cache for C++ applications
-     
+
       \section Introduction
-     
+
      STL::Cache is just a simple wrapper over standard map, that implements some cache algorithms, thus allowing you to limit the storage size
      and automatically remove unused items from it. (Right now the std::map interface is partially implemented, so it can't be used as a drop-in replacement for the std::map).
-     
+
      It is intented to be used for keeping any key/value data, especially when data's size are too big, to just put it into the map and keep the whole thing.
      With STL::Cache you could put unlimited (really unlimited) amount of data into it, but it will store only some small part of your data. So re-usable
-     data will be kept near your code and not so popular data will not spend expensive memory. 
-     
+     data will be kept near your code and not so popular data will not spend expensive memory.
+
      STL::Cache uses configurable policies, for decisions, whether data are good, to be kept in cache or they should be thrown away. It is shipped with
-     8 policies and you are free to implement your own.        
-     
+     8 policies and you are free to implement your own.
+
      \section GaI Getting and installing
-     
+
      The STL::Cache source code is hosted on <a href="https://github.com/akashihi/stlcache">github</a>, so you can download the source code
      using wget or other download tool:
-     
+
      \li https://github.com/akashihi/stlcache/tarball/master (tar.gz format)
      \li https://github.com/akashihi/stlcache/zipball/master (or zip format)
-     
+
      You could also clone the repository and check some unstable code:
-     
+
      \code
      git clone git://github.com/akashihi/stlcache.git
      \endcode
-     
+
      The 'master' branch is always pointing to the latest stable release and the 'next' branch is a unstable development branch.
-     
+
      The STL::Cache is header only and does not require any building. Just copy the include/stlcache directory to your system's include directories or
      add it to your project's  include directories. Alternativaly you could build the sources and then install it, using our build system.
-     
+
      Yes, as i told you, the STL::Cache themself is a header-only library and doesn't requires building. Indeed, it is shipped with tests, documentation and
      other stuff, that could be built and used. For STL::Cache building you need:
-     
+
      \li <a href="http://www.cmake.org/">Recent CMake (required)</a>
      \li <a href="http://www.boost.org/">Boost library (optional, used only for tests)</a>
      \li <a href="http://www.doxygen.org/">Doxygen (optional, only for documentation processing)</a>
-     
+
      After getting this stuff up and running, select a directory for building and issue the following commands:
-     
+
      \code
         cmake /path/to/the/stlcache/sources
         make
@@ -78,44 +78,44 @@ namespace stlcache {
         make doc
         make install
     \endcode
-     
+
      The CMake is using a <a href="http://www.cmake.org/Wiki/CMake_FAQ#Out-of-source_build_trees">out-of-source</a> build approach,
      so it is recommended to create a temporary build directory somewhere and remove it after installation.
-     
+
      The generated documentation will be put into the \<build\>/doc directory and tests will be built and run directly in the \<build\> directory. They are NOT
      installed by 'make install' command, so you have to copy them manually, if you really need them.
-     
+
      \section Usage
-     
+
      Select a \link stlcache::policy cache expiration policy \endlink, configure \link stlcache::cache cache \endlink with it, construct the cache, specifying it's size, and start putting data into the cache:
-     
+
      \code
      typedef CacheLRU stlcache::cache<int,string,stlcache::policy_lru>;
      CacheLRU myCache(10);
      \endcode
-     
+
      The policy, key data type and value data type are passed as parameters to the \link stlcache::cache \endlink class template. In the example above
      we have constructed cache, that keeps data of type std::string and keys are of type int. It uses a \link stlcache::policy_lru LRU \endlink policy
      for removal of excessive items. Cache object 'myCache' is able to keep only 10 items. Cache size is configured at the construction time and
      cannot be changed in the future (with exceptions for assignment and swap operations). Additionally you could specify a comparision object and
      allocator type, see the \link stlcache::cache cache class \endlink documentation for the details.
-     
+
      You could put objects into your cache object using \link cache::insert insert \endlink call:
-     
+
      \code
      myCache.insert(1,"One)";
      \endcode
-     
+
      Note, that the \link cache::insert insert \endlink call could throw a \link stlcache::exception_cache_full cache full exception \endlink or
      \link stlcache::exception_invalid_key invalid key exception \endlink As keys have to be unique, the insert call may do nothing, if it meets the
      duplicate key. Don't forget to check it's return value.
-     
+
      Now, when you have some data in the cache, you may want to retrieve it back:
-     
+
      \code
      string myOne = myCache.fetch(1);
      \endcode
-     
+
      The \link cache::fetch fetch \endlink call will return a data value, associated with the supplied key or throw the \link stlcache::exception_invalid_key invalid key exception \endlink
      when the key doesn't exists in the cache. For safier operations, you could \link cache::check check \endlink in advance, whether key is in the cache or not:
      \code
@@ -124,31 +124,31 @@ namespace stlcache {
        myOne = myCache.fetch(1);
      }
      \endcode
-     
+
      The \link cache::check check \endlink is exception-safe.
-     
+
      Both \link cache::check check \endlink and \link cache::fetch fetch \endlink calls are increasing internal reference count for the key, so, depending
      on the used policy, it will increase or decrease the entry's chance to become an expiration victim. Under some circumstances you may
      need to manually change those reference counter, without actually accesing the entry. Something like \link cache::touch touching \endlink it:
      \code
      myCache.touch(1);
      \endcode
-     
+
      The \link cache::touch \endlink call is exception-safe and could be used even on non-existent keys.
-     
+
      When you have done your work, you may manually delete the entry:
-     
+
      \code
      myCache.erase(1);
      \endcode
-     
+
      Check it's return value, to get sure, whether something was deleted or not.
-     
+
      \section Policies
-     
+
      The \link stlcache::policy policy \endlink is a pluggable implementation of a cache algorithms, used for finding and removing excessive
      cache entries. STL::Cache is shipped with the following policies:
-     
+
      \li \link stlcache::policy_none None \endlink - A random expiration policy. Removes some random entry on request
      \li \link stlcache::policy_lru LRU \endlink - 'Least recently used' policy.
      \li \link stlcache::policy_mru MRU \endlink - 'Most recentrly used' policy
@@ -157,49 +157,49 @@ namespace stlcache {
      \li \link stlcache::policy_lfuaging LFU-Aging \endlink - 'Least frequently used' policy with time-based decreasing of usage count
      \li \link stlcache::policy_lfuagingstar LFU*-Aging \endlink - Combination of \link stlcache::policy_lfustar LFU* \endlink and \link stlcache::policy_lfuagingstar LFU*-Aging \endlink policies
      \li \link stlcache::policy_adaptive Adaptive Replacement \endlink - 'Adaptive Replacement' policy
-     
+
      The cache expiration policy must be specified as a third parameter of \link stlcache::cache cache \endlink type and it is mandatory.
-     
+
      \section Writing your own policy
-     
+
      The policy implementation should keep track of entries in the cache and it must be able to tell the cache, what item should be expired at the moment.
      There is not any limitations on policy internal structure and stuff, but it is expected, that policy conforms to some predefined interfaces.
-     
+
      First of all - every policy is built in two classes, one class is the policy iteslf, and another one is a 'bind wrapper':
-     
+
      \note All code examples in this section are from \link stlcache::policy_none  policy none \endlink
-     
+
      \code
         struct policy_none {
         template <typename Key, template <typename T> class Allocator>
-            struct bind : _policy_none_type<Key,Allocator> { 
+            struct bind : _policy_none_type<Key,Allocator> {
                 bind(const bind& x) : _policy_none_type<Key,Allocator>(x)  { }
                 bind(const size_t& size) : _policy_none_type<Key,Allocator>(size) { }
             };
         };
      \endcode
-     
+
      As you may see, the policy itself is automatically configured with caches's Key type and Allocator type. Of course, you could also pass
      your own template parameters and partially instantiate the policy implementation template:
-     
+
      \code
         template <class R> struct policy_none {
             template <typename Key, template <typename T> class Allocator>
-                struct bind : _policy_none_type<R,Key,Allocator> { 
+                struct bind : _policy_none_type<R,Key,Allocator> {
                     bind(const bind& x) : _policy_none_type<R,Key,Allocator>(x) { }
                     bind(const size_t& size) : _policy_none_type<R,Key,Allocator>(size) { }
                 };
-        };     
+        };
      \endcode
-     
+
      You could pass some implementation of R during cache type definition:
-     
+
      \code
          stlcache::cache<int,int,stlcache::policy_none<Randomizer> > c;
      \endcode
-     
+
      Well, the actual implementation must implement the \link stlcache::policy policy interface \endlink :
-     
+
      \code
         template <class Key,template <typename T> class Allocator> class policy {
             public:
@@ -209,14 +209,14 @@ namespace stlcache {
             virtual void clear() =0;
             virtual void swap(policy<Key,Allocator>& _p)=0;
             virtual const _victim<Key> victim()  =0;
-        };     
+        };
      \endcode
-     
+
      So, the policy could be asked for a \link policy::victim victim \endlink, entries could be \link policy::insert inserted \endlink ,
      \link policy::remove removed \endlink and \link policy::touch touched \endlink. It's contents could also be \link policy::clear cleared \endlink
      or \link policy::swap swapped \endlink with another policy. Concrete policy implementation should be CopyConstructible, Assignable and
      must provide a constructor, for specifiying policy size:
-     
+
      \code
         template <class Key, template <typename T> class Allocator> class _policy_none_type : public policy<Key,Allocator> {
         public:
@@ -233,31 +233,31 @@ namespace stlcache {
             virtual const _victim<Key> victim() {}
         };
      \endcode
-     
+
      It's up to you, how you will implement those methods and so on. The only importatn thing, we haven't mentioned yet, is a
      \link stlcache::_victim victim \endlink class. It is a way to return optional value from a function. So, when your policy implementatiton
      cannot find any entry to remove, it will return empty victim object.
-     
+
      \section AaL  Authors and Licensing
-     
+
      Copyright (C) 2011 Denis V Chapligin
      Distributed under the Boost Software License, Version 1.0.
      (See accompanying file LICENSE_1_0.txt or copy at
      http://www.boost.org/LICENSE_1_0.txt)
-     
+
       */
 
     /*! \brief Cache is a kind of a map that have limited number of elements to store and configurable policy for autoremoval of excessive elements.
-     *  
-     * The cache behaviour resembles a std::map behaviour (but not yet fully compatible with usual std::map interface), but it adds a limitation of 
-     * maximum number of entries, stored in cache and  provides a configurable policy, which is used to remove entries when the cache is full. 
-     *  
-     * Internally it is built as a wrapper over a std::map with some additional checking for cache size and entry removal logic. Unfortunately not all interfaces 
-     * of std::map are supperted by now, but it is a work in progress. 
-     *  
-     * You can use the cache in a simple and obvious way: 
-     * \code 
-     *     cache<string,string,policy_lru> cache_lru(3); 
+     *
+     * The cache behaviour resembles a std::map behaviour (but not yet fully compatible with usual std::map interface), but it adds a limitation of
+     * maximum number of entries, stored in cache and  provides a configurable policy, which is used to remove entries when the cache is full.
+     *
+     * Internally it is built as a wrapper over a std::map with some additional checking for cache size and entry removal logic. Unfortunately not all interfaces
+     * of std::map are supperted by now, but it is a work in progress.
+     *
+     * You can use the cache in a simple and obvious way:
+     * \code
+     *     cache<string,string,policy_lru> cache_lru(3);
      *     cache_lru.insert("key","value");
      *     cache_lru.touch("key");
      *     if (cache_lru.check("key")) {
@@ -265,42 +265,42 @@ namespace stlcache {
      *     }
      *     cache_lru.erase("key");
      * \endcode
-     *  
-     * So you define a cache instance, specifying a Key type, a Data type and a Policy, passing maximum number of entries to the constructor. 
-     * You could \link cache::insert insert \endlink as 
-     * many entries as you like, even more entries, that cache instance can hold. When the cache starts to overflow, it will automatically 
-     * remove entries, depending on specified Policy. 
-     * You can \link cache::touch touch \endlink some entries, to advance their usage count, that may (or may not, depending on Policy) 
-     * help them survive the removal on cache overflow. You can \link cache::erase \endlink entries manually too. 
-     * For the data retrieval you should first \link cache::check check \endlink , whether Key exists in 
-     * cache or not, and \link cache::fetch fetch \endlink it, if it exists. 
-     * The preliminary \link cache::fetch fetch \endlink step is not neccessary, but fetching non-existent key will throw an \link 	exception_invalid_key exception \endlink . 
-     *  
-     * cache class have three mandatory template parameters and two optional: 
-     * \tparam <Key> The key data type. We have no limitations on this type, so it could be any built-in type, custom class etc. But it is recommended to supply a less-than operation for a Key type. 
-     * \tparam <Data> The value data type. You a free to use any type here without any restrictions, requirements and recommendations. 
-     * \tparam <Policy> The expiration policy type. Must implement \link stlcache::policy policy interface \endlink STL::Cache provides several expiration policies out-of-box and you are free to define new policies. 
-     * \tparam <Compare> Comparison class: A class that takes two arguments of the key type and returns a bool. The expression comp(a,b), where comp is an object of this comparison class and a and b are key values, shall return true if a is to be placed at an earlier position than b in a strict weak ordering operation. This can either be a class implementing a function call operator or a pointer to a function (see constructor for an example). This defaults to less<Key>, which returns the same as applying the less-than operator (a<b). This is required for the underlying std::map 
-     * \tparam <Allocator> Type of the allocator object used to define the storage allocation model. Unlike std::map you should pass a unspecialized Allocator type. 
-     *  
-     * So, the full example of cache instantiation will be: 
-     * \code 
+     *
+     * So you define a cache instance, specifying a Key type, a Data type and a Policy, passing maximum number of entries to the constructor.
+     * You could \link cache::insert insert \endlink as
+     * many entries as you like, even more entries, that cache instance can hold. When the cache starts to overflow, it will automatically
+     * remove entries, depending on specified Policy.
+     * You can \link cache::touch touch \endlink some entries, to advance their usage count, that may (or may not, depending on Policy)
+     * help them survive the removal on cache overflow. You can \link cache::erase \endlink entries manually too.
+     * For the data retrieval you should first \link cache::check check \endlink , whether Key exists in
+     * cache or not, and \link cache::fetch fetch \endlink it, if it exists.
+     * The preliminary \link cache::fetch fetch \endlink step is not neccessary, but fetching non-existent key will throw an \link 	exception_invalid_key exception \endlink .
+     *
+     * cache class have three mandatory template parameters and two optional:
+     * \tparam <Key> The key data type. We have no limitations on this type, so it could be any built-in type, custom class etc. But it is recommended to supply a less-than operation for a Key type.
+     * \tparam <Data> The value data type. You a free to use any type here without any restrictions, requirements and recommendations.
+     * \tparam <Policy> The expiration policy type. Must implement \link stlcache::policy policy interface \endlink STL::Cache provides several expiration policies out-of-box and you are free to define new policies.
+     * \tparam <Compare> Comparison class: A class that takes two arguments of the key type and returns a bool. The expression comp(a,b), where comp is an object of this comparison class and a and b are key values, shall return true if a is to be placed at an earlier position than b in a strict weak ordering operation. This can either be a class implementing a function call operator or a pointer to a function (see constructor for an example). This defaults to less<Key>, which returns the same as applying the less-than operator (a<b). This is required for the underlying std::map
+     * \tparam <Allocator> Type of the allocator object used to define the storage allocation model. Unlike std::map you should pass a unspecialized Allocator type.
+     *
+     * So, the full example of cache instantiation will be:
+     * \code
      *     cache<int,string,policy_none,less<string>,std::allocator> cache_none(100500);
      * \endcode
-     *  
-     * \see policy 
-     *  
+     *
+     * \see policy
+     *
      * \author chollya (5/19/2011)
      */
     template<
-        class Key, 
-        class Data, 
-        class Policy, 
-        class Compare = less<Key>, 
-        template <typename T> class Allocator = allocator 
+        class Key,
+        class Data,
+        class Policy,
+        class Compare = less<Key>,
+        template <typename T> class Allocator = allocator
     >
     class cache {
-        typedef map<Key,Data,Compare,Allocator<pair<const Key, Data> > > storageType; 
+        typedef map<Key,Data,Compare,Allocator<pair<const Key, Data> > > storageType;
          storageType _storage;
          std::size_t _maxEntries;
          std::size_t _currEntries;
@@ -309,86 +309,86 @@ namespace stlcache {
          Allocator<policy_type> policyAlloc;
 
     public:
-        /*! \brief The Key type 
+        /*! \brief The Key type
          */
         typedef Key                                                                key_type;
-        /*!  \brief The Data type 
+        /*!  \brief The Data type
          */
         typedef Data                                                               mapped_type;
-        /*! \brief Combined key,value type 
+        /*! \brief Combined key,value type
           */
         typedef pair<const Key, Data>                                         value_type;
         /*! \brief Compare type used by this instance
           */
         typedef Compare                                                          key_compare;
-        /*! \brief Allocator type used by this instance 
+        /*! \brief Allocator type used by this instance
           */
         typedef Allocator<pair<const Key, Data> >                          allocator_type;
-        /*! \brief Nested class to compare elements (see member function value_comp) 
+        /*! \brief Nested class to compare elements (see member function value_comp)
           */
         typedef typename storageType::value_compare                                value_compare;
-        /*! \brief Allocator::reference 
+        /*! \brief Allocator::reference
           */
         typedef typename storageType::reference                                        reference;
-        /*! \brief Allocator::const_reference 
+        /*! \brief Allocator::const_reference
           */
         typedef typename storageType::const_reference                               const_reference;
-        /*! \brief Type used for storing object sizes, specific to a current platform (usually a size_t) 
+        /*! \brief Type used for storing object sizes, specific to a current platform (usually a size_t)
           */
         typedef typename storageType::size_type                                       size_type;
-        /*! \brief Type used for address calculations, specific to a current platform (usually a ptrdiff_t) 
+        /*! \brief Type used for address calculations, specific to a current platform (usually a ptrdiff_t)
           */
         typedef typename storageType::difference_type                               difference_type;
-        /*! \brief Allocator::pointer 
+        /*! \brief Allocator::pointer
           */
         typedef typename storageType::pointer                                          pointer;
-        /*! \brief Allocator::const_pointer 
+        /*! \brief Allocator::const_pointer
           */
         typedef typename storageType::const_pointer                                 const_pointer;
 
-        /*! \name std::map interface wrappers 
+        /*! \name std::map interface wrappers
          *  Simple wrappers for std::map calls, that we are using only for mimicking the map interface
          */
         //@{
         /*! \brief Allocator object accessor
-          *                                                                                                                                          
+          *
           *  Provides access to the allocator object, used to constuct the container.
           *
-          *  \return The allocator object of type Allocator<pair<const Key, Data> >.                
+          *  \return The allocator object of type Allocator<pair<const Key, Data> >.
           */
         allocator_type get_allocator() const {
             return _storage.get_allocator();
         }
 
         /*! \brief Counts entries with specified key in the cache.
-          *  
+          *
           *  Provides information on number of cache entries with specific key. It is not very usefull, as keys are unique in the cache.
           *  The difference between thic member and \link cache::check check member \endlink is that this one returns number of keys
           *  without touching the entry usage count.
-          *  
+          *
           *  \param <x> key to count
-          *  
+          *
           *  \return Number of objects with specified key in the cache (ie 1 if object is on the cache and 0 for non-existent object)
           *
           *  \see check
-          *  
-          */        
+          *
+          */
         size_type count ( const key_type& x ) const {
             return _storage.count(x);
         }
 
         /*! \brief Value comparision object accessor
-         *  
-         *   Provides access to a comparison object that can be used to compare two element values (pairs) to get whether the key of the first goes before the second. The mapped value, although part of the pair, is not taken into consideration in this comparison - only the key value.  
-         *  
+         *
+         *   Provides access to a comparison object that can be used to compare two element values (pairs) to get whether the key of the first goes before the second. The mapped value, although part of the pair, is not taken into consideration in this comparison - only the key value.
+         *
          *   \return The value comparison object of type value_compare, defined as described above.
          */
         value_compare value_comp ( ) const {
             return _storage.value_comp();
         }
 
-        /*! \brief Key comparision object accessor 
-          * 
+        /*! \brief Key comparision object accessor
+          *
           *  Provides access to the  comparison object associated with the container, which can be used to compare the keys of two elements in the container.
           *  This comparison object is set on object construction, and may either be a pointer to a function or an object of a class with a function call operator.
           *  In both cases it takes two arguments of the same type as the element keys,
@@ -402,15 +402,15 @@ namespace stlcache {
             return _storage.key_comp();
         }
 
-        /*! \brief Test whether cache is empty 
-          *  
+        /*! \brief Test whether cache is empty
+          *
           *  Tells whether the map container is empty, i.e. whether its size is 0. This function does not modify the content of the container in any way. In terms of performance it is not equal to call
           *  \code
           *      cache.size()==0
           *   \endcode
-          *  
+          *
           *   \return true if the container size is 0, false otherwise.
-          *  
+          *
           *   \see size
           */
         bool empty() const {
@@ -418,36 +418,36 @@ namespace stlcache {
         }
         //@}
 
-        /*! \name cache api 
+        /*! \name cache api
          *  members that are specific to cache or implemented with some cache specific things
          */
         //@{
         /*!
          * \brief Clear the cache
-         *  
-         * Removes all cache entries, drops all usage count data and so on. 
-         *  
-         * \see size 
-         * \see empty 
-         *  
+         *
+         * Removes all cache entries, drops all usage count data and so on.
+         *
+         * \see size
+         * \see empty
+         *
          */
         void clear() {
             _storage.clear();
             _policy->clear();
             this->_currEntries=0;
         }
-        
+
         /*!
-         * \brief Swaps contents of two caches 
-         *  
-         * Exchanges the content of the cache with the content of mp, which is another cache object containing elements of the same type and using the same expiration policy. 
+         * \brief Swaps contents of two caches
+         *
+         * Exchanges the content of the cache with the content of mp, which is another cache object containing elements of the same type and using the same expiration policy.
          * Sizes may differ. Maximum number of entries may differ too.
-         *  
-         * \param <mp> Another cache of the same type as this whose cache is swapped with that of this cache. 
-         *  
-         * \throw <exception_invalid_policy> Thrown when the policies of the caches to swap are incompatible. 
-         *  
-         * \see cache::operator= 
+         *
+         * \param <mp> Another cache of the same type as this whose cache is swapped with that of this cache.
+         *
+         * \throw <exception_invalid_policy> Thrown when the policies of the caches to swap are incompatible.
+         *
+         * \see cache::operator=
          */
         void swap ( cache<Key,Data,Policy,Compare,Allocator>& mp ) {
             _storage.swap(mp._storage);
@@ -462,14 +462,14 @@ namespace stlcache {
         }
 
         /*!
-         * \brief Removes a entry from cache 
-         *  
-         * The entry with the specified key value will be removed from cache and it's usage count information will be erased. Size of the cache will be decreased. 
+         * \brief Removes a entry from cache
+         *
+         * The entry with the specified key value will be removed from cache and it's usage count information will be erased. Size of the cache will be decreased.
          *  For non-existing entries nothing will be done.
-         *  
-         * \param <x> Key to remove.  
-         *  
-         * \return 1 when entry is removed (ie number of removed emtries, which is always 1, as keys are unique) or zero when nothing was done. 
+         *
+         * \param <x> Key to remove.
+         *
+         * \return 1 when entry is removed (ie number of removed emtries, which is always 1, as keys are unique) or zero when nothing was done.
          */
         size_type erase ( const key_type& x ) {
             size_type ret=_storage.erase(x);
@@ -481,16 +481,16 @@ namespace stlcache {
         }
 
         /*!
-         * \brief Insert element to the cache 
-         *  
-         * The cache is extended by inserting a single new element. This effectively increases the cache size. Because cache do not allow for duplicate key values, the insertion operation checks for each element inserted whether another element exists already in the container with the same key value, if so, the element is not inserted and its mapped value is not changed in any way. 
-         * Extension of cache could result in removal of some elements, depending of the cache fullness and used policy. It is also possible, that removal of excessive entries 
-         * will fail, therefore insert operation will fail too. 
-         * 
-         * \throw <exception_cache_full>  Thrown when there are no available space in the cache and policy doesn't allows removal of elements. 
-         * \throw <exception_invalid_key> Thrown when the policy doesn't accepts the key 
-         *  
-         * \return true if the new elemented was inserted or false if an element with the same key existed. 
+         * \brief Insert element to the cache
+         *
+         * The cache is extended by inserting a single new element. This effectively increases the cache size. Because cache do not allow for duplicate key values, the insertion operation checks for each element inserted whether another element exists already in the container with the same key value, if so, the element is not inserted and its mapped value is not changed in any way.
+         * Extension of cache could result in removal of some elements, depending of the cache fullness and used policy. It is also possible, that removal of excessive entries
+         * will fail, therefore insert operation will fail too.
+         *
+         * \throw <exception_cache_full>  Thrown when there are no available space in the cache and policy doesn't allows removal of elements.
+         * \throw <exception_invalid_key> Thrown when the policy doesn't accepts the key
+         *
+         * \return true if the new elemented was inserted or false if an element with the same key existed.
          */
         bool insert(Key _k, Data _d) {
             while (this->_currEntries >= this->_maxEntries) {
@@ -514,45 +514,45 @@ namespace stlcache {
 
         /*!
          * \brief Maximum cache size accessor
-         *  
-         * Returns the maximum number of elements that the cache object can hold. This is the maximum potential size the cache can reach. It is specified at 
-         * construction time and cannot be modified (with excaption of \link cache::swap swap operation \endlink) 
-         *  
-         * \return The maximum number of elements a cache can have as its content. 
-         *  
-         * \see size 
+         *
+         * Returns the maximum number of elements that the cache object can hold. This is the maximum potential size the cache can reach. It is specified at
+         * construction time and cannot be modified (with excaption of \link cache::swap swap operation \endlink)
+         *
+         * \return The maximum number of elements a cache can have as its content.
+         *
+         * \see size
          */
         size_type max_size() const {
             return this->_maxEntries;
         }
 
         /*! \brief Counts entries in the cache.
-          *  
-          *  Provides information on number of cache entries. For checking, whether the cache empty or not, please use the \link cache::empty empty function \endlink 
-          *  
+          *
+          *  Provides information on number of cache entries. For checking, whether the cache empty or not, please use the \link cache::empty empty function \endlink
+          *
           *  \return Number of object in the cache (size of cache)
-          *  
+          *
           *  \see empty
           *  \see clear
-          */        
+          */
         size_type size() const {
             assert(this->_currEntries==_storage.size());
             return this->_currEntries;
         }
 
         /*!
-         * \brief Access cache data 
-         *  
-         * Accessor to the data (values) stored in cache. If the specified key exists in the cache, it's usage count will be touched and reference to the element is returned. 
-         * The data object itself is kept in the cache, so the reference will be valid until it is removed (either manually or due to cache overflow) or cache object destroyed. 
-         *  
-         * \param <_k> key to the data 
-         * 
+         * \brief Access cache data
+         *
+         * Accessor to the data (values) stored in cache. If the specified key exists in the cache, it's usage count will be touched and reference to the element is returned.
+         * The data object itself is kept in the cache, so the reference will be valid until it is removed (either manually or due to cache overflow) or cache object destroyed.
+         *
+         * \param <_k> key to the data
+         *
          * \throw  <exception_invalid_key> Thrown when non-existent key is supplied. You could use \link cache::check check member \endlink or \link cache::count count member \endlink to check cache existence prior to fetching the data
-         *  
-         * \return constand reference to the data, mapped by the key. of type Data of course. 
-         *  
-         * \see check 
+         *
+         * \return constand reference to the data, mapped by the key. of type Data of course.
+         *
+         * \see check
          */
         const Data& fetch(const Key& _k) {
             if (!check(_k)) {
@@ -564,14 +564,14 @@ namespace stlcache {
 
         /*!
          * \brief Check for the key presence in cache
-         *  
+         *
          *  Tests, whether cache is exist in the cache or not. During check it's usage count is increased, as opposed to \link cache::count count member \endlink
-         *  
+         *
          *  \param <_k> key to test
-         *  
-         * \return true if key exists in the cache and false otherwise 
-         *  
-         * \see count 
+         *
+         * \return true if key exists in the cache and false otherwise
+         *
+         * \see count
          */
         const bool check(const Key& _k) {
             _policy->touch(_k);
@@ -579,13 +579,13 @@ namespace stlcache {
         }
 
         /*!
-         * \brief Increase usage count for entry 
-         *  
+         * \brief Increase usage count for entry
+         *
          *  Touches an entry in cache, simulating access to it. Usefull to promote (or devote, depending on policy) item in the cache, reducing(or increasing)
          *  risk for expiration for it.
-         *  
+         *
          *  \param _k key to touch
-         *  
+         *
          */
         void touch(const Key& _k) {
             _policy->touch(_k);
@@ -595,16 +595,16 @@ namespace stlcache {
         //@{
         /*!
          * \brief Copy cache content
-         *  
+         *
          * Assigns a copy of the elements in x as the new content for the cache. Usage counts for entries are copied too.
-         * The elements contained in the object before the call are dropped, and replaced by copies of those in cache x, if any. 
+         * The elements contained in the object before the call are dropped, and replaced by copies of those in cache x, if any.
          * After a call to this member function, both the map object and x will have the same size and compare equal to each other.
-         *  
-         * \param <x> a cache object with the same template parameters 
-         *  
-         * \return *this 
-         *  
-         * \see swap 
+         *
+         * \param <x> a cache object with the same template parameters
+         *
+         * \return *this
+         *
+         * \see swap
          */
         cache<Key,Data,Policy,Compare,Allocator>& operator= ( const cache<Key,Data,Policy,Compare,Allocator>& x) {
             this->_storage=x._storage;
@@ -619,23 +619,23 @@ namespace stlcache {
 
         /*!
          * \brief A copy constructor
-         * 
+         *
          *  The object is initialized to have the same contents and properties as the x cache object.
-         *  
-         *  \param <x> a cache object with the same template parameters 
+         *
+         *  \param <x> a cache object with the same template parameters
          */
         cache(const cache<Key,Data,Policy,Compare,Allocator>& x) {
             *this=x;
         }
         /*!
-         * \brief Primary constructor. 
-         *  
-         * Constructs an empty cache object and sets a maximum size for it. It is the only way to set size for a cache and it can't be changed later. 
-         * You could also  pass optional comparator object, compatible with Compare. 
-         *  
-         * \param <size> Maximum number of entries, allowed in the cache. 
-         * \param <comp> Comparator object, compatible with Compare type. Defaults to Compare() 
-         * 
+         * \brief Primary constructor.
+         *
+         * Constructs an empty cache object and sets a maximum size for it. It is the only way to set size for a cache and it can't be changed later.
+         * You could also  pass optional comparator object, compatible with Compare.
+         *
+         * \param <size> Maximum number of entries, allowed in the cache.
+         * \param <comp> Comparator object, compatible with Compare type. Defaults to Compare()
+         *
          */
         explicit cache(const size_type size, const Compare& comp = Compare()) {
             this->_storage=storageType(comp, Allocator<pair<const Key, Data> >());
@@ -648,10 +648,10 @@ namespace stlcache {
         }
 
         /*!
-         * \brief destructor 
-         *  
-         * Destructs the cache object. This calls each of the cache element's destructors, and deallocates all the storage capacity allocated by the cache. 
-         * 
+         * \brief destructor
+         *
+         * Destructs the cache object. This calls each of the cache element's destructors, and deallocates all the storage capacity allocated by the cache.
+         *
          */
         ~cache() {
             policyAlloc.destroy(this->_policy);

--- a/include/stlcache/victim.hpp
+++ b/include/stlcache/victim.hpp
@@ -15,18 +15,18 @@ using namespace std;
 namespace stlcache {
     /*!
      * \brief Wrapper for optional values
-     *  
-     * Used as interface between \link stlcache::policy policies \endlink and  \link stlcache::cache \endlink themself. The problem is that the policy 
-     * may not be able to select a entry to remove from the cache, when requested.  So it may return an entry from the \link policy::victim victim call \endlink 
-     * or may not return anything. Cause we do not have overloading based on return value, we have to use some wrapper. 
-     *  
-     * The _victim class is parameterized with the key type and initialized with  some value or without any value. Constructed _victim object 
-     * cannot be changed in the future, so you can't add a value to the empty object or clear filled object.  
-     *  
-     * \tparam <Key> a type to wrap 
-     *  
-     * \see stlcache::policy 
-     *  
+     *
+     * Used as interface between \link stlcache::policy policies \endlink and  \link stlcache::cache \endlink themself. The problem is that the policy
+     * may not be able to select a entry to remove from the cache, when requested.  So it may return an entry from the \link policy::victim victim call \endlink
+     * or may not return anything. Cause we do not have overloading based on return value, we have to use some wrapper.
+     *
+     * The _victim class is parameterized with the key type and initialized with  some value or without any value. Constructed _victim object
+     * cannot be changed in the future, so you can't add a value to the empty object or clear filled object.
+     *
+     * \tparam <Key> a type to wrap
+     *
+     * \see stlcache::policy
+     *
      * \author chollya (5/20/2011)
      */
     template <class Key> class _victim {
@@ -34,38 +34,38 @@ namespace stlcache {
         bool _isInitialized;
     public:
         /*!
-         * \brief default constructor 
-         *  
-         * Constructs empty wrapper object, with no data in it. 
-         *  
+         * \brief default constructor
+         *
+         * Constructs empty wrapper object, with no data in it.
+         *
          */
         _victim() : _value(NULL), _isInitialized(false) { };
         /*!
-         * \brief initializing constructor 
-         *  
-         * Construct wrapper object and initializes it with supplied data. 
-         * 
+         * \brief initializing constructor
+         *
+         * Construct wrapper object and initializes it with supplied data.
+         *
          * \param _v data to keep in the wrapper
          */
         _victim(const Key& _v) : _value(const_cast<Key&>(_v)),_isInitialized(true) { };
 
         /*!
-         * \brief Copy constructor 
-         *  
-         * Constructs an object, exactly equal to the supplied source. Both data (or it's absence) and state are copied. 
-         * The source object must be of the same type (including template parameters) as the constructed object 
-         * 
+         * \brief Copy constructor
+         *
+         * Constructs an object, exactly equal to the supplied source. Both data (or it's absence) and state are copied.
+         * The source object must be of the same type (including template parameters) as the constructed object
+         *
          * \param _source a _victim object with the same template parameters
          */
         _victim(const _victim<Key>& _source) : _value(_source._value),_isInitialized(_source._isInitialized)  { }
         /*!
-         * \brief Copy victim content 
-         *  
+         * \brief Copy victim content
+         *
          *  Assigns a copy of the data and the state of _source as the new content for the wrapper. It may convert a
          *  empty object to the object with data and vice versa.
-         *  
-         *  \param <_source> a _victim object with the same template parameters 
-         *  
+         *
+         *  \param <_source> a _victim object with the same template parameters
+         *
          * \return *this
          */
         _victim<Key>& operator= ( const _victim<Key>& _source) {
@@ -76,34 +76,34 @@ namespace stlcache {
 
         /*!
          * \brief Check for wrapper emptiness
-         *  
+         *
          * Provides information, whether wrapper is containing some data or not.
-         *  
+         *
          * \return true when wrapper object contains some data or false, when it's empty
-         *  
+         *
          */
         const bool isInitialized() const {
             return this->_isInitialized;
         }
         /*!
          * \brief cast to bool operator
-         * 
+         *
          * Wrapper over \link _victim::isInitialized \endlink call, just to make it's use more intuitive and clearier.
          * Usefull for checking _victim objects in the natural way:
-         * 
+         *
          * \code
          *   if (victimObject) {
          *       cout<<"Have some data"<<victimObject.value()<<endl;
          *   } else {
          *       cout<<"No data available"<<endl;
          *   }
-         * 
+         *
          *   \endcode
-         * 
-         * \return true when wrapper object contains some data or false, when it's empty 
-         * 
-         * \see _victim::isInitialized 
-         *  
+         *
+         * \return true when wrapper object contains some data or false, when it's empty
+         *
+         * \see _victim::isInitialized
+         *
          */
         operator const bool() const {
             return this->_isInitialized;
@@ -111,12 +111,12 @@ namespace stlcache {
 
         /*!
          * \brief Wrapped data accessor
-         * 
-         * Provides access to the data, kept in the wrapper. Will throw exception, when called on the empty 
-         * wrapper object, so use \link _victim::isInitialized \endlink proir fetching. 
-         *  
-         * \throw <exception_empty_victim> Thrown when tried to access data in the empty wrapper object 
-         *  
+         *
+         * Provides access to the data, kept in the wrapper. Will throw exception, when called on the empty
+         * wrapper object, so use \link _victim::isInitialized \endlink proir fetching.
+         *
+         * \throw <exception_empty_victim> Thrown when tried to access data in the empty wrapper object
+         *
          * \return the wrapped value
          */
         const Key& value() const {
@@ -127,24 +127,24 @@ namespace stlcache {
         }
         /*!
          * \brief Dereferencing operator
-         *  
-         * Wrapper over \link _victim::value \endlink call, to make it's use more clearier. 
+         *
+         * Wrapper over \link _victim::value \endlink call, to make it's use more clearier.
          * Usefull for getting the data in a natural way:
-         *  
+         *
          * \code
          *   if (victimObject) {
          *       cout<<"Have some data"<<*victimObject<<endl;
          *   } else {
          *       cout<<"No data available"<<endl;
          *   }
-         * 
+         *
          *  \endcode
-         *  
-         * \throw <exception_empty_victim> Thrown when tried to access data in the empty wrapper object 
-         *  
-         * \return the wrapped value 
-         *  
-         * \see _victim::value 
+         *
+         * \throw <exception_empty_victim> Thrown when tried to access data in the empty wrapper object
+         *
+         * \return the wrapped value
+         *
+         * \see _victim::value
          */
         const Key& operator*() const {
             return this->value();

--- a/include/stlcache/victim.hpp
+++ b/include/stlcache/victim.hpp
@@ -68,7 +68,7 @@ namespace stlcache {
          *  
          * \return *this
          */
-        _victim<Key>& operator= ( const _victim<Key>& _source) throw() {
+        _victim<Key>& operator= ( const _victim<Key>& _source) {
             this->_value=_source._value;
             this->_isInitialized=_source._isInitialized;
             return *this;
@@ -82,7 +82,7 @@ namespace stlcache {
          * \return true when wrapper object contains some data or false, when it's empty
          *  
          */
-        const bool isInitialized() const throw() {
+        const bool isInitialized() const {
             return this->_isInitialized;
         }
         /*!
@@ -105,7 +105,7 @@ namespace stlcache {
          * \see _victim::isInitialized 
          *  
          */
-        operator const bool() const throw() {
+        operator const bool() const {
             return this->_isInitialized;
         }
 
@@ -119,7 +119,7 @@ namespace stlcache {
          *  
          * \return the wrapped value
          */
-        const Key& value() const throw(exception_empty_victim) {
+        const Key& value() const {
             if(!this->_isInitialized) {
                 throw exception_empty_victim("Tried to access empty victim");
             }
@@ -146,7 +146,7 @@ namespace stlcache {
          *  
          * \see _victim::value 
          */
-        const Key& operator*() const throw(exception_empty_victim) {
+        const Key& operator*() const {
             return this->value();
         }
     };

--- a/include/stlcache/victim.hpp
+++ b/include/stlcache/victim.hpp
@@ -39,7 +39,7 @@ namespace stlcache {
          * Constructs empty wrapper object, with no data in it.
          *
          */
-        _victim() : _value(NULL), _isInitialized(false) { };
+        _victim() : _isInitialized(false) { };
         /*!
          * \brief initializing constructor
          *

--- a/tests/test_copy.cpp
+++ b/tests/test_copy.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(copyLFUAgingStar) {
     c1.insert(3,"data3");
 
     c1.touch(1); //For key one refcount is 3 now
-    c1.touch(1); 
+    c1.touch(1);
     c1.touch(2); //For key two refcount is 3 now
     c1.touch(2);
     c1.touch(3); //For key three refcount is 2 now

--- a/tests/test_insdel_perf.cpp
+++ b/tests/test_insdel_perf.cpp
@@ -7,10 +7,11 @@
 
 #define BOOST_TEST_MODULE "STLCacheInsertDeletePerformance"
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 
 #ifdef _WIN32
 #include "timeval.h"
-#else 
+#else
 #include <sys/time.h>
 #endif /* _WIN32 */
 
@@ -25,201 +26,201 @@ const unsigned int noItems = 65536;
 BOOST_AUTO_TEST_CASE(insdelNone) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_none> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelLRU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lru> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Remocal of "<<noItems<<" items from policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Remocal of "<<noItems<<" items from policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelMRU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_mru> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelLFU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfu> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelLFUStar) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfustar> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelLFUAging) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfuaging<3600> > c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelLFUAgingStar) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfuagingstar<3600> > c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insdelAdaptive) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_adaptive> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.erase(indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Removal of "<<noItems<<" items from policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Removal of "<<noItems<<" items from policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/tests/test_insert_perf.cpp
+++ b/tests/test_insert_perf.cpp
@@ -7,10 +7,11 @@
 
 #define BOOST_TEST_MODULE "STLCacheInsertPerformance"
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 
 #ifdef _WIN32
 #include "timeval.h"
-#else 
+#else
 #include <sys/time.h>
 #endif /* _WIN32 */
 
@@ -25,121 +26,121 @@ const unsigned int noItems = 65536;
 BOOST_AUTO_TEST_CASE(insertNone) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_none> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertLRU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lru> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertMRU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_mru> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertLFU) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfu> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertLFUStar) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfustar> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertLFUAging) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfuaging<3600> > c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertLFUAgingStar) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_lfuagingstar<3600> > c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertAdaptive) {
     struct timeval start,stop;
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     cache<unsigned int,unsigned int,policy_adaptive> c(noItems);
     for(unsigned int indx = 0; indx<noItems; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/tests/test_lfuaging.cpp
+++ b/tests/test_lfuaging.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(expire) {
     c1.insert(3,"data3");
 
     c1.touch(1); //For key one refcount is 3 now
-    c1.touch(1); 
+    c1.touch(1);
     c1.touch(1);
     c1.touch(2); //For key two refcount is 3 now
     c1.touch(2);

--- a/tests/test_lfuagingstar.cpp
+++ b/tests/test_lfuagingstar.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(veryfrequent) {
     c1.touch(2);
     c1.touch(3);
 
-    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Because every entry in cache have reference counter bigger then one and 
+    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Because every entry in cache have reference counter bigger then one and
                                                                                                     //lfu* policy works only on entries with refcount equal to 1
 
     c1.erase(1);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(expire) {
     c1.insert(3,"data3");
 
     c1.touch(1); //For key one refcount is 3 now
-    c1.touch(1); 
+    c1.touch(1);
     c1.touch(2); //For key two refcount is 3 now
     c1.touch(2);
     c1.touch(3); //For key three refcount is 2 now
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(expirefail) {
     c1.insert(3,"data3");
 
     c1.touch(1); //For key one refcount is 4 now
-    c1.touch(1); 
+    c1.touch(1);
     c1.touch(1);
     c1.touch(2); //For key two refcount is 4 now
     c1.touch(2);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(expirefail) {
 
     WAIT_A_SECOND;
 
-    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Cause even in expired cache there are no entries with refcount 1 
+    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Cause even in expired cache there are no entries with refcount 1
 
     WAIT_A_SECOND;
 

--- a/tests/test_lfustar.cpp
+++ b/tests/test_lfustar.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(veryfrequent) {
     c1.touch(2);
     c1.touch(3);
 
-    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Because every entry in cache have reference counter bigger then one and 
+    BOOST_REQUIRE_THROW(c1.insert(4,"data4"),exception_cache_full); //Because every entry in cache have reference counter bigger then one and
                                                                                                     //lfustar policy works only on entries with refcount equal to 1
 
     c1.erase(1);

--- a/tests/test_lru.cpp
+++ b/tests/test_lru.cpp
@@ -39,4 +39,37 @@ BOOST_AUTO_TEST_CASE(touch) {
     BOOST_REQUIRE_THROW(c1.fetch(2),exception_invalid_key); //Must be removed by LRU policy (cause 1 is touched)
 }
 
+BOOST_AUTO_TEST_CASE(assign) {
+    cache<int,string,policy_lru> c1(3);
+
+    c1.insert(1,"data1");
+    c1.insert(2,"data2");
+    c1.insert(3,"data3");
+
+    cache<int,string,policy_lru> c2 = c1;
+    c2.touch(1);
+
+    c2.insert(4,"data4");
+
+    BOOST_REQUIRE_THROW(c2.fetch(2),exception_invalid_key); //Must be removed by LRU policy (cause 1 is touched)
+}
+
+BOOST_AUTO_TEST_CASE(clear) {
+    cache<int,string,policy_lru> c1(3);
+
+    c1.insert(1,"data1");
+    c1.insert(2,"data2");
+    c1.insert(3,"data3");
+
+    c1.clear();
+
+    BOOST_REQUIRE_THROW(c1.fetch(1),exception_invalid_key);
+
+    c1.insert(4,"data4");
+    c1.insert(5,"data5");
+
+    c1.fetch(4);
+    c1.fetch(5);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/tests/test_victim_perf.cpp
+++ b/tests/test_victim_perf.cpp
@@ -7,10 +7,11 @@
 
 #define BOOST_TEST_MODULE "STLCacheVictimPerformance"
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 
 #ifdef _WIN32
 #include "timeval.h"
-#else 
+#else
 #include <sys/time.h>
 #endif /* _WIN32 */
 
@@ -30,15 +31,15 @@ BOOST_AUTO_TEST_CASE(victimNone) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_none cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimLRU) {
@@ -49,15 +50,15 @@ BOOST_AUTO_TEST_CASE(victimLRU) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_lru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimMRU) {
@@ -68,15 +69,15 @@ BOOST_AUTO_TEST_CASE(victimMRU) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_mru cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimLFU) {
@@ -87,15 +88,15 @@ BOOST_AUTO_TEST_CASE(victimLFU) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_lfu cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimLFUStar) {
@@ -106,15 +107,15 @@ BOOST_AUTO_TEST_CASE(victimLFUStar) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_lfustar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimLFUAging) {
@@ -125,15 +126,15 @@ BOOST_AUTO_TEST_CASE(victimLFUAging) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_lfuaging cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(victimLFUAgingStar) {
@@ -144,15 +145,15 @@ BOOST_AUTO_TEST_CASE(victimLFUAgingStar) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_lfuagingstar cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_CASE(insertAdaptive) {
@@ -163,15 +164,15 @@ BOOST_AUTO_TEST_CASE(insertAdaptive) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&start, NULL); 
+    gettimeofday(&start, NULL);
 
     for(unsigned int indx = noItems; indx<noItems*2; indx++) {
         c.insert(indx,indx);
     }
 
-    gettimeofday(&stop, NULL); 
+    gettimeofday(&stop, NULL);
 
-    cout<<"Insertion of "<<noItems<<" excessive items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
+    std::cout<<"Insertion of "<<noItems<<" excessive items into policy_adaptive cache took "<<((stop.tv_sec-start.tv_sec)*1000)+((stop.tv_usec-start.tv_usec)/1000)<<" milliseconds"<<endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This updates things to work with CMake 3.10, Boost 1.66, and C++ 11 (using GCC 7.2.0 in my case).